### PR TITLE
ci: use larger runners for slow jobs

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   cargo-check:
     name: cargo check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-8core
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -23,7 +23,7 @@ jobs:
 
   cargo-test:
     name: cargo test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-8core
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -45,7 +45,7 @@ jobs:
 
   cargo-doc:
     name: cargo doc
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-8core
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
 
   cargo-clippy:
     name: cargo clippy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-8core
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -81,7 +81,7 @@ jobs:
 
   cargo-fix:
     name: cargo fix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-8core
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
#### Problem

really painful for those > 18 mins jobs.

<img width="243" alt="Screenshot 2024-10-31 at 00 37 34" src="https://github.com/user-attachments/assets/49294953-aa37-4e2c-9ae7-4d96d651e19e">

#### Summary of Changes

use larger runners for them