### PR TITLE
ci: use sccache for Github Actions

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -9,6 +9,10 @@ on:
     branches: [main]
   pull_request:
 
+env:
+  SCCACHE_GHA_ENABLED: "true"
+  RUSTC_WRAPPER: "sccache"
+
 jobs:
   cargo-check:
     name: cargo check
@@ -18,6 +22,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Rust Toolchain
         run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo check
         run: cargo check --workspace --all-features
 
@@ -29,6 +35,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Rust Toolchain
         run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo test
         run: cargo test --workspace --all-features
 
@@ -40,6 +48,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Rust Toolchain
         run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo fmt
         run: cargo fmt -- --check
 
@@ -51,6 +61,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Rust Toolchain
         run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo doc
         run: cargo doc --workspace --all-features
 
@@ -62,6 +74,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Rust Toolchain
         run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: Install cargo-audit
         run: cargo install cargo-audit
       - name: cargo audit
@@ -76,6 +90,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Rust Toolchain
         run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo clippy
         run: cargo clippy --workspace --all-features
 
@@ -87,6 +103,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up Rust Toolchain
         run: curl https://sh.rustup.rs -sSf | sh -s -- -y
+      - name: Run sccache-cache
+        uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo fix --workspace
         run: |
           # Run cargo fix on the project


### PR DESCRIPTION
the first run:
<img width="352" alt="Screenshot 2024-10-31 at 01 43 31" src="https://github.com/user-attachments/assets/0d661c17-8095-4c5b-b30d-f5884640cf46">

the second run:
<img width="303" alt="Screenshot 2024-10-31 at 01 43 22" src="https://github.com/user-attachments/assets/607da3fc-d403-466b-a564-b317ceeac213">
