### PR TITLE
ci: remove redundant rust setup steps

### DIFF
--- a/.github/workflows/rust.yaml
+++ b/.github/workflows/rust.yaml
@@ -20,8 +20,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Rust Toolchain
-        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo check
@@ -33,8 +31,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Rust Toolchain
-        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo test
@@ -46,8 +42,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Rust Toolchain
-        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo fmt
@@ -59,8 +53,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Rust Toolchain
-        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo doc
@@ -72,8 +64,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Rust Toolchain
-        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
       - name: Install cargo-audit
@@ -88,8 +78,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Rust Toolchain
-        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo clippy
@@ -101,8 +89,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Rust Toolchain
-        run: curl https://sh.rustup.rs -sSf | sh -s -- -y
       - name: Run sccache-cache
         uses: mozilla-actions/sccache-action@v0.0.6
       - name: cargo fix --workspace


### PR DESCRIPTION
we already have a `rust-toolchain.toml` file in this repository, which ensures the correct Rust version is selected automatically when running cargo commands. I guess there’s no need to explicitly set the Rust version in the GitHub Actions steps 🤔 