### PR TITLE
chore: disable default-features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1086,12 +1086,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cityhash-rs"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93a719913643003b84bd13022b4b7e703c09342cd03b679c4641c7d2e50dc34d"
-
-[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,26 +1118,19 @@ checksum = "9a9a81a1dffadd762ee662635ce409232258ce9beebd7cc0fa227df0b5e7efc0"
 dependencies = [
  "bstr",
  "bytes",
- "cityhash-rs",
  "clickhouse-derive",
  "futures 0.3.31",
  "futures-channel",
  "http-body-util",
  "hyper 1.7.0",
  "hyper-util",
- "lz4_flex",
- "quanta",
  "replace_with",
  "sealed",
  "serde",
- "serde_json",
- "sha-1 0.10.1",
  "static_assertions",
  "thiserror 1.0.69",
- "time",
  "tokio",
  "url 2.5.7",
- "uuid",
 ]
 
 [[package]]
@@ -3571,12 +3558,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lz4_flex"
-version = "0.11.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
-
-[[package]]
 name = "match-lookup"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5392,17 +5373,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha-1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5058ada175748e33390e40e872bd0fe59a19f265d0158daa551c5a88a76009c"
-dependencies = [
- "cfg-if 1.0.3",
- "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5582,7 +5552,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.8.5",
- "sha-1 0.9.8",
+ "sha-1",
 ]
 
 [[package]]
@@ -9898,16 +9868,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "uuid"
-version = "1.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,41 +22,41 @@ repository.workspace = true
 documentation.workspace = true
 
 [workspace.dependencies]
-jetstreamer-firehose = { path = "jetstreamer-firehose", version = "0.1.0" }
-jetstreamer-plugin = { path = "jetstreamer-plugin", version = "0.1.0" }
-jetstreamer-utils = { path = "jetstreamer-utils", version = "0.1.0" }
-tokio = { version = "1", features = ["full"] }
-futures-util = "0"
+jetstreamer-firehose = { path = "jetstreamer-firehose", version = "0.1.3" }
+jetstreamer-plugin = { path = "jetstreamer-plugin", version = "0.1.3" }
+jetstreamer-utils = { path = "jetstreamer-utils", version = "0.1.3" }
+tokio = "1"
+futures-util = { version = "0", default-features = false }
 futures = "0"
 log = "0"
 once_cell = "1"
-serde_json = "1"
-thiserror = "2"
-reqwest = { version = "0.12", features = ["stream", "blocking", "json"] }
-anyhow = "1"
+serde_json = { version = "1", default-features = false }
+thiserror = { version = "2", default-features = false }
+reqwest = { version = "0.12", default-features = false }
+anyhow = { version = "1", default-features = false }
 base64 = "0.22"
 bincode = "1"
-bs58 = "0"
+bs58 = { version = "0", default-features = false }
 cbor = "0"
 cid = "0"
 colored = "2"
 const-hex = "1"
 crc = "3"
-crossbeam-channel = "0"
-crossbeam-utils = "0"
-fnv = "1"
-url = "2"
-multihash = "0"
-prost = { package = "prost", version = "0" }
+crossbeam-channel = { version = "0", default-features = false }
+crossbeam-utils = { version = "0", default-features = false }
+fnv = { version = "1", default-features = false }
+url = { version = "2", default-features = false }
+multihash = { version = "0", default-features = false }
+prost = { package = "prost", version = "0", default-features = false }
 prost_011 = { package = "prost", version = "0.11" }
 protobuf-src = "1"
-serde = "1"
+serde = { version = "1", default-features = false }
 serde_cbor = "0"
 agave-geyser-plugin-interface = "3"
 solana-hash = "3"
 solana-logger = "3"
 solana-pubkey = "3"
-solana-signature = "3"
+solana-signature = { version = "3", default-features = false }
 solana-accounts-db = "3"
 solana-entry = "3"
 solana-ledger = "3"
@@ -70,17 +70,17 @@ solana-transaction-status = "3"
 solana-sdk-ids = "3"
 solana-reward-info = "3"
 sha2 = "0.10"
-tonic = "0"
+tonic = { version = "0", default-features = false }
 tonic-build = "0"
-zstd = "0"
+zstd = { version = "0", default-features = false }
 thousands = "0"
-tokio-stream = { version = "0", features = ["full"] }
+tokio-stream = { version = "0", default-features = false }
 rangemap = "1"
 rseek = ">= 0.2"
 rayon = "1"
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
 dashmap = "5"
-clickhouse = { version = ">= 0.13", features = ["uuid", "time", "lz4", "watch", "inserter"] }
+clickhouse = { version = ">= 0.13", default-features = false }
 interprocess = { version = "2", features = ["tokio"] }
 ctrlc = "3"
 indoc = "2"

--- a/jetstreamer-utils/Cargo.toml
+++ b/jetstreamer-utils/Cargo.toml
@@ -21,7 +21,7 @@ name = "clickhouse-client"
 path = "src/clickhouse_client_bin.rs"
 
 [dependencies]
-tokio.workspace = true
+tokio = { workspace = true, features = ["full"] }
 log.workspace = true
 tempfile.workspace = true
 libc.workspace = true


### PR DESCRIPTION
### Problem

some crates are imported with default features that are not needed

### Summary of Changes
- add `default-features = false` to workspace dependencies
- bump `jetstreamer-firehose`, `jetstreamer-plugin`, and `jetstreamer-plugin` from `0.1.0` to `0.1.3`

cc @sam0x17 