### PR TITLE
fix: seek before slot

### DIFF
--- a/jetstreamer-firehose/src/firehose.rs
+++ b/jetstreamer-firehose/src/firehose.rs
@@ -40,7 +40,7 @@ use crate::{
         FetchEpochStreamOptions, epoch_to_slot_range, fetch_epoch_stream,
         fetch_epoch_stream_with_options, slot_to_epoch,
     },
-    index::{SLOT_OFFSET_INDEX, SlotOffsetIndexError, slot_to_offset},
+    index::{SLOT_OFFSET_INDEX, SlotOffsetIndexError},
     node_reader::NodeReader,
     utils,
 };
@@ -87,49 +87,6 @@ fn is_shutdown_error(err: &FirehoseError) -> bool {
         | FirehoseError::OnStatsHandlerError(inner) => is_interrupted(inner.as_ref()),
         _ => false,
     }
-}
-
-async fn find_previous_indexed_slot(
-    local_start: u64,
-    epoch_start: u64,
-    log_target: &str,
-) -> Result<Option<u64>, FirehoseError> {
-    if local_start <= epoch_start {
-        return Ok(None);
-    }
-    let mut candidate = local_start.saturating_sub(1);
-    let mut skipped = 0u64;
-    loop {
-        match slot_to_offset(candidate).await {
-            Ok(_) => {
-                if skipped > 0 {
-                    log::info!(
-                        target: log_target,
-                        "slot {} missing in index; seeking back {} slots to {}",
-                        local_start.saturating_sub(1),
-                        skipped,
-                        candidate
-                    );
-                }
-                return Ok(Some(candidate));
-            }
-            Err(SlotOffsetIndexError::SlotNotFound(..)) => {
-                if candidate <= epoch_start {
-                    break;
-                }
-                skipped += 1;
-                candidate = candidate.saturating_sub(1);
-            }
-            Err(err) => return Err(FirehoseError::SlotOffsetIndexError(err)),
-        }
-    }
-    log::warn!(
-        target: log_target,
-        "no indexed slot found before {} (epoch start {}); reading from epoch start",
-        local_start,
-        epoch_start
-    );
-    Ok(None)
 }
 
 /// Errors that can occur while streaming the firehose. Errors that can occur while streaming
@@ -1114,36 +1071,18 @@ where
                         }
 
                     if local_start > epoch_start {
-                        // Seek to the nearest previous indexed slot so the stream includes all
+                        // Seek to the previous slot so the stream includes all
                         // nodes (transactions, entries, rewards) that precede `local_start`.
-                        let seek_slot = match timeout(
-                            OP_TIMEOUT,
-                            find_previous_indexed_slot(local_start, epoch_start, &log_target),
-                        )
-                        .await
-                        {
-                            Ok(res) => res.map_err(|e| (e, current_slot.unwrap_or(slot_range.start)))?,
+                        let seek_fut = reader.seek_before_slot(local_start);
+                        match timeout(op_timeout, seek_fut).await {
+                            Ok(res) => {
+                                res.map_err(|e| (e, current_slot.unwrap_or(slot_range.start)))?
+                            }
                             Err(_) => {
                                 return Err((
-                                    FirehoseError::OperationTimeout(
-                                        "seek_to_previous_indexed_slot",
-                                    ),
+                                    FirehoseError::OperationTimeout("seek_before_slot"),
                                     current_slot.unwrap_or(slot_range.start),
                                 ));
-                            }
-                        };
-                        if let Some(seek_slot) = seek_slot {
-                            let seek_fut = reader.seek_to_slot(seek_slot);
-                            match timeout(op_timeout, seek_fut).await {
-                                Ok(res) => {
-                                    res.map_err(|e| (e, current_slot.unwrap_or(slot_range.start)))?
-                                }
-                                Err(_) => {
-                                    return Err((
-                                        FirehoseError::OperationTimeout("seek_to_slot"),
-                                        current_slot.unwrap_or(slot_range.start),
-                                    ));
-                                }
                             }
                         }
                     }
@@ -2084,36 +2023,18 @@ async fn firehose_geyser_thread(
                 current_slot = None;
 
                 if local_start > epoch_start {
-                    // Seek to the nearest previous indexed slot so the reader captures the full
+                    // Seek to the previous slot so the reader captures the full
                     // node set (transactions, entries, rewards) for the target block.
-                    let seek_slot = match timeout(
-                        OP_TIMEOUT,
-                        find_previous_indexed_slot(local_start, epoch_start, &log_target),
-                    )
-                    .await
-                    {
-                        Ok(res) => res.map_err(|e| (e, current_slot.unwrap_or(slot_range.start)))?,
+                    let seek_fut = reader.seek_before_slot(local_start);
+                    match timeout(OP_TIMEOUT, seek_fut).await {
+                        Ok(res) => {
+                            res.map_err(|e| (e, current_slot.unwrap_or(slot_range.start)))?
+                        }
                         Err(_) => {
                             return Err((
-                                FirehoseError::OperationTimeout(
-                                    "seek_to_previous_indexed_slot",
-                                ),
+                                FirehoseError::OperationTimeout("seek_before_slot"),
                                 current_slot.unwrap_or(slot_range.start),
                             ));
-                        }
-                    };
-                    if let Some(seek_slot) = seek_slot {
-                        let seek_fut = reader.seek_to_slot(seek_slot);
-                        match timeout(OP_TIMEOUT, seek_fut).await {
-                            Ok(res) => {
-                                res.map_err(|e| (e, current_slot.unwrap_or(slot_range.start)))?
-                            }
-                            Err(_) => {
-                                return Err((
-                                    FirehoseError::OperationTimeout("seek_to_slot"),
-                                    current_slot.unwrap_or(slot_range.start),
-                                ));
-                            }
                         }
                     }
                 }

--- a/jetstreamer-firehose/src/node_reader.rs
+++ b/jetstreamer-firehose/src/node_reader.rs
@@ -1,6 +1,6 @@
 use crate::LOG_MODULE;
 use crate::SharedError;
-use crate::epochs::slot_to_epoch;
+use crate::epochs::{epoch_to_slot_range, slot_to_epoch};
 use crate::firehose::FirehoseError;
 use crate::index::{SlotOffsetIndexError, slot_to_offset};
 use crate::node::{Node, NodeWithCid, NodesWithCids, parse_any_from_cbordata};
@@ -252,6 +252,72 @@ impl<R: AsyncRead + Unpin + AsyncSeek + Len> NodeReader<R> {
             }
         }
     }
+
+    /// Seeks to the slot immediately before `target_slot` so that the next
+    /// [`read_until_block`](Self::read_until_block) call reads the preceding
+    /// slot's block node, and the *following* read captures `target_slot`'s
+    /// full data (transactions, entries, and block).
+    ///
+    /// This is necessary because `seek_to_slot` positions the reader at the
+    /// block node's offset, but transactions and entries for a slot are stored
+    /// *before* the block node in the CAR file. Without this, the first slot
+    /// in a range would be missing its transactions.
+    ///
+    /// If no preceding slot exists in the index (e.g. `target_slot` is the
+    /// first slot in its epoch), this is a no-op — the reader stays at the
+    /// beginning of the epoch so the full data is read sequentially.
+    pub async fn seek_before_slot(&mut self, target_slot: u64) -> Result<(), FirehoseError> {
+        let epoch_start = epoch_to_slot_range(slot_to_epoch(target_slot)).0;
+
+        // Walk backwards from target_slot - 1 to the epoch start looking for
+        // a slot that exists in the index.
+        let mut probe = target_slot.saturating_sub(1);
+        while probe >= epoch_start {
+            match slot_to_offset(probe).await {
+                Ok(offset) => {
+                    let epoch = slot_to_epoch(probe);
+                    log::info!(
+                        target: LOG_MODULE,
+                        "Seeking before slot {} → landed on slot {} in epoch {} @ offset {}",
+                        target_slot,
+                        probe,
+                        epoch,
+                        offset
+                    );
+
+                    if self.header.is_empty() {
+                        self.read_raw_header()
+                            .await
+                            .map_err(FirehoseError::SeekToSlotError)?;
+                    }
+
+                    wait_for_seek_hit_slot().await;
+                    self.reader
+                        .seek(SeekFrom::Start(offset))
+                        .await
+                        .map_err(|e| FirehoseError::SeekToSlotError(Box::new(e)))?;
+                    return Ok(());
+                }
+                Err(SlotOffsetIndexError::SlotNotFound(..)) => {
+                    if probe == epoch_start {
+                        break;
+                    }
+                    probe -= 1;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        // No preceding slot found — stay at the beginning of the epoch so the
+        // sequential read picks up the target slot's full data naturally.
+        log::info!(
+            target: LOG_MODULE,
+            "No preceding slot found for {}; reading from epoch start",
+            target_slot
+        );
+        Ok(())
+    }
+
 
     #[allow(clippy::should_implement_trait)]
     /// Reads the next raw node from the Old Faithful stream without parsing it.


### PR DESCRIPTION
# Problem
`seek_to_slot` jumped directly to a slot's block node offset, but transactions/entries are stored before the block in the CAR file. So the first slot in a range would miss all its transactions.

# Fix
New `seek_before_slot()` on `NodeReader` seeks to the previous slot's block offset instead. The first `read_until_block()` consumes that previous slot's block (skipped by the main loop's range check), and the next read captures the target slot's full data from the beginning.