### PR TITLE
feat: add jetstreamer-dex-trades plugin — decode swaps from 30 Solana…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1389,12 +1389,35 @@ checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
 
 [[package]]
 name = "borsh"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115e54d64eb62cdebad391c19efc9dce4981c690c85a33a12199d99bb9546fee"
+dependencies = [
+ "borsh-derive 0.10.4",
+ "hashbrown 0.13.2",
+]
+
+[[package]]
+name = "borsh"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d1da5ab77c1437701eeff7c88d968729e7766172279eab0676857b3d63af7a6f"
 dependencies = [
- "borsh-derive",
+ "borsh-derive 1.6.0",
  "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831213f80d9423998dd696e2c5345aba6be7a0bd8cd19e31c5243e13df1cef89"
+dependencies = [
+ "borsh-derive-internal",
+ "borsh-schema-derive-internal",
+ "proc-macro-crate 0.1.5",
+ "proc-macro2",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1408,6 +1431,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "borsh-derive-internal"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65d6ba50644c98714aa2a70d13d7df3cd75cd2b523a2b452bf010443800976b3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "borsh-schema-derive-internal"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "276691d96f063427be83e6692b86148e488ebba9f48f77788724ca027ba3b6d4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -2185,7 +2230,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.111",
 ]
 
 [[package]]
@@ -3857,6 +3902,7 @@ name = "jetstreamer"
 version = "0.5.0"
 dependencies = [
  "clickhouse",
+ "jetstreamer-dex-trades",
  "jetstreamer-firehose",
  "jetstreamer-plugin",
  "jetstreamer-utils",
@@ -3868,6 +3914,30 @@ dependencies = [
  "solana-sysvar",
  "tokio",
  "url 2.5.7",
+]
+
+[[package]]
+name = "jetstreamer-dex-trades"
+version = "0.5.0"
+dependencies = [
+ "base64 0.22.1",
+ "borsh 0.10.4",
+ "bs58",
+ "byteorder",
+ "chrono",
+ "clickhouse",
+ "dashmap",
+ "futures-util",
+ "jetstreamer-firehose",
+ "jetstreamer-plugin",
+ "log",
+ "once_cell",
+ "prost 0.11.9",
+ "prost-build 0.13.5",
+ "solana-address 1.1.0",
+ "solana-message",
+ "solana-transaction-status",
+ "tokio",
 ]
 
 [[package]]
@@ -3890,7 +3960,7 @@ dependencies = [
  "log",
  "multihash",
  "once_cell",
- "prost",
+ "prost 0.11.9",
  "reqwest 0.12.24",
  "ripget",
  "rseek",
@@ -5256,6 +5326,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5310,7 +5390,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.11.9",
+]
+
+[[package]]
+name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -5326,13 +5416,33 @@ dependencies = [
  "log",
  "multimap",
  "petgraph",
- "prettyplease",
- "prost",
- "prost-types",
+ "prettyplease 0.1.25",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "regex",
  "syn 1.0.109",
  "tempfile",
  "which",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck 0.5.0",
+ "itertools 0.13.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease 0.2.37",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn 2.0.111",
+ "tempfile",
 ]
 
 [[package]]
@@ -5349,12 +5459,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.13.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "prost-types"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "213622a1460818959ac1181aaeb2dc9c7f63df720db7d788b3e24eacd1983e13"
 dependencies = [
- "prost",
+ "prost 0.11.9",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -6738,7 +6870,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e37320fd2945c5d654b2c6210624a52d66c3f1f73b653ed211ab91a703b35bdd"
 dependencies = [
- "borsh",
+ "borsh 1.6.0",
  "bytemuck",
  "bytemuck_derive",
  "curve25519-dalek 4.1.3",
@@ -6873,7 +7005,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc402b16657abbfa9991cd5cbfac5a11d809f7e7d28d3bb291baeb088b39060e"
 dependencies = [
- "borsh",
+ "borsh 1.6.0",
 ]
 
 [[package]]
@@ -7188,7 +7320,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8292c436b269ad23cecc8b24f7da3ab07ca111661e25e00ce0e1d22771951ab9"
 dependencies = [
- "borsh",
+ "borsh 1.6.0",
  "solana-instruction",
  "solana-sdk-ids",
 ]
@@ -7827,7 +7959,7 @@ dependencies = [
  "mockall",
  "num_cpus",
  "num_enum",
- "prost",
+ "prost 0.11.9",
  "qualifier_attr",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
@@ -8251,7 +8383,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1af32c995a7b692a915bb7414d5f8e838450cf7c70414e763d8abcae7b51f28"
 dependencies = [
- "borsh",
+ "borsh 1.6.0",
 ]
 
 [[package]]
@@ -9102,8 +9234,8 @@ dependencies = [
  "hyper-proxy",
  "log",
  "openssl",
- "prost",
- "prost-types",
+ "prost 0.11.9",
+ "prost-types 0.11.9",
  "serde",
  "smpl_jwt",
  "solana-clock",
@@ -9131,7 +9263,7 @@ checksum = "f59231870d0ddabf9860c0a22ecdef8ff8f778aa4105d7ad8a4ac18bc1efd428"
 dependencies = [
  "bincode",
  "bs58",
- "prost",
+ "prost 0.11.9",
  "protobuf-src",
  "serde",
  "solana-account-decoder",
@@ -9561,7 +9693,7 @@ dependencies = [
  "agave-reserved-account-keys",
  "base64 0.22.1",
  "bincode",
- "borsh",
+ "borsh 1.6.0",
  "bs58",
  "log",
  "serde",
@@ -9899,7 +10031,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6433917b60441d68d99a17e121d9db0ea15a9a69c0e5afa34649cf5ba12612f"
 dependencies = [
- "borsh",
+ "borsh 1.6.0",
  "solana-instruction",
  "solana-pubkey 3.0.0",
 ]
@@ -9966,7 +10098,7 @@ version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1233fdecd7461611d69bb87bc2e95af742df47291975d21232a0be8217da9de"
 dependencies = [
- "borsh",
+ "borsh 1.6.0",
  "bytemuck",
  "bytemuck_derive",
  "num-derive",
@@ -10082,7 +10214,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c467c7c3bd056f8fe60119e7ec34ddd6f23052c2fa8f1f51999098063b72676"
 dependencies = [
- "borsh",
+ "borsh 1.6.0",
  "num-derive",
  "num-traits",
  "solana-borsh",
@@ -10613,7 +10745,7 @@ dependencies = [
  "hyper-timeout",
  "percent-encoding 2.3.2",
  "pin-project",
- "prost",
+ "prost 0.11.9",
  "rustls-pemfile",
  "tokio",
  "tokio-rustls 0.24.1",
@@ -10630,9 +10762,9 @@ version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6fdaae4c2c638bb70fe42803a26fbd6fc6ac8c72f5c59f67ecc2a2dcabf4b07"
 dependencies = [
- "prettyplease",
+ "prettyplease 0.1.25",
  "proc-macro2",
- "prost-build",
+ "prost-build 0.11.9",
  "quote",
  "syn 1.0.109",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["jetstreamer-firehose", "jetstreamer-plugin", "jetstreamer-utils"]
+members = ["jetstreamer-firehose", "jetstreamer-plugin", "jetstreamer-utils", "jetstreamer-dex-trades"]
 
 [workspace.package]
 edition = "2024"
@@ -30,6 +30,7 @@ verify-transaction-signatures = ["jetstreamer-firehose/verify-transaction-signat
 jetstreamer-firehose = { path = "jetstreamer-firehose", version = "0.5.0" }
 jetstreamer-plugin = { path = "jetstreamer-plugin", version = "0.5.0" }
 jetstreamer-utils = { path = "jetstreamer-utils", version = "0.5.0" }
+jetstreamer-dex-trades = { path = "jetstreamer-dex-trades", version = "0.5.0" }
 tokio = "1"
 futures-util = { version = "0", default-features = false }
 futures = "0"
@@ -102,6 +103,8 @@ aws-credential-types = "1"
 aws-sdk-s3 = "1"
 aws-smithy-types = "1"
 aws-types = "1"
+chrono = { version = "0.4", default-features = false }
+byteorder = "1.5"
 
 [dependencies]
 tokio.workspace = true
@@ -110,6 +113,7 @@ log.workspace = true
 jetstreamer-firehose.workspace = true
 jetstreamer-plugin.workspace = true
 jetstreamer-utils.workspace = true
+jetstreamer-dex-trades.workspace = true
 url.workspace = true
 solana-sysvar.workspace = true
 solana-blake3-hasher.workspace = true

--- a/jetstreamer-dex-trades/Cargo.toml
+++ b/jetstreamer-dex-trades/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "jetstreamer-dex-trades"
+description = "Solana DEX trades decoder plugin for Jetstreamer — decodes swaps from 28+ DEX programs into protobuf SwapRecords"
+keywords.workspace = true
+edition.workspace = true
+version.workspace = true
+authors = ["topledger", "sam0x17", "anza-team"]
+license.workspace = true
+repository.workspace = true
+documentation.workspace = true
+
+[dependencies]
+jetstreamer-firehose.workspace = true
+jetstreamer-plugin.workspace = true
+
+# Solana types
+solana-address.workspace = true
+solana-message.workspace = true
+solana-transaction-status.workspace = true
+
+# Serialization
+borsh = "0.10"
+byteorder.workspace = true
+base64.workspace = true
+bs58.workspace = true
+
+# Protobuf
+prost.workspace = true
+
+# Async
+tokio.workspace = true
+futures-util.workspace = true
+
+# Data structures
+dashmap.workspace = true
+once_cell.workspace = true
+
+# Time
+chrono.workspace = true
+
+# Logging
+log.workspace = true
+
+# ClickHouse — required by the Plugin trait signature
+clickhouse.workspace = true
+
+[build-dependencies]
+prost-build = "0.13"

--- a/jetstreamer-dex-trades/README.md
+++ b/jetstreamer-dex-trades/README.md
@@ -1,0 +1,132 @@
+# jetstreamer-dex-trades
+
+Solana DEX trades decoder plugin for [Jetstreamer](https://github.com/anza-xyz/jetstreamer). Decodes swap transactions from 30 DEX programs into a unified protobuf `SwapRecord`.
+
+Contributed by [Top Ledger](https://topledger.xyz/) ([@ledger_top](https://x.com/ledger_top)) — Solana blockchain analytics and data infrastructure.
+
+## Supported DEXes
+
+Covers all major Solana DEXes plus proprietary AMMs (SolFi, AlphaQ, BisonFi, ZeroFi, GoonFi, HumidiFi, Tessera, and others).
+
+| DEX | Program ID |
+|-----|-----------|
+| Pump Fun | `6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P` |
+| Pump AMM | `pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA` |
+| Raydium AMM V4 | `675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8` |
+| Raydium CPMM | `CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C` |
+| Raydium CLMM | `CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK` |
+| Raydium LaunchLab | `LanMV9sAd7wArD4vJFi2qDdfnVhFxYSUg6eADduJ3uj` |
+| Orca Whirlpool | `whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc` |
+| Orca V2 | `9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP` |
+| Meteora DAMM V2 | `cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG` |
+| Meteora DBC | `dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN` |
+| Meteora DLMM | `LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo` |
+| Meteora Pools | `Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB` |
+| Manifest | `MNFSTqtC93rEfYHB6hF82sKdZpUDFWkViLByLd1k1Ms` |
+| Aquifer | `AQU1FRd7papthgdrwPTTq5JacJh8YtwEXaBfKU3bTz45` |
+| Lifinity V1 | `EewxydAPCCVuNEyrVN68PuSYdQ7wKn27V9Gjeoi8dy3S` |
+| Lifinity V2 | `2wT8Yq49kHgDzXuPxZSaeLaH1qbmGXtEyPy64bL7aD3c` |
+| PancakeSwap CLMM | `HpNfyc2Saw7RKkQd8nEL4khUcuPhQ7WwY1B2qjx8jxFq` |
+| Byreal CLMM | `REALQqNEomY6cQGZJUGwywTBD2UmDT32rZcNnfxQ5N2` |
+| Futarchy AMM | `FUTARELBfJfQ8RDGhg1wdhddq1odMAJUePHFuBYfUxKq` |
+| Obric V2 | `obriQD1zbpyLz95G5n7nJe6a4DPjpFwa5XYPoNm113y` |
+| SolFi V1 | `SoLFiHG9TfgtdUXUjWAxi3LtvYuFyDLVhBWxdMZxyCe` |
+| SolFi V2 | `SV2EYYJyRz2YhfXwXnhNAevDEui5Q6yrfyo13WtupPF` |
+| AlphaQ | `ALPHAQmeA7bjrVuccPsYPiCvsi428SNwte66Srvs4pHA` |
+| BisonFi | `BiSoNHVpsVZW2F7rx2eQ59yQwKxzU5NvBcmKshCSUypi` |
+| ZeroFi | `ZERor4xhbUycZ6gb9ntrhqscUcZmAbQDjEAtCf4hbZY` |
+| GoonFi | `goonERTdGsjnkZqWuVjs73BZ3Pb9qoCUdBUL17BnS5j` |
+| HumidiFi | `9H6tua7jkLhdm3w8BvgpTn5LZNU7g4ZynDmCiNN3q6Rp` |
+| Tessera | `TessVdML9pBGgG9yGks7o4HewRaXVAMuoVj4x83GLQH` |
+| Stabble Stable | `swapNyd8XiQwJ6ianp9snpu4brUqFxadzvHebnAXjJZ` |
+| Stabble Weighted | `swapFpHZwjELNnjvThjajtiVmkz3yPQEHjLtka2fwHW` |
+
+## Output Schema
+
+Primary output is protobuf. Each slot produces a `DexTradesBatch` containing `SwapRecord` messages:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `block_slot` | uint64 | Slot number |
+| `block_time` | int64 | Unix timestamp (seconds) |
+| `block_date` | string | `YYYY-MM-DD` |
+| `tx_id` | string | Base58 transaction signature |
+| `tx_index` | uint32 | Transaction index within block |
+| `instruction_index` | uint32 | Outer instruction index (1-based) |
+| `inner_instruction_index` | uint32 | Inner index (1-based, 0 if outer) |
+| `is_inner_instruction` | bool | Whether this is a CPI call |
+| `instruction_type` | string | e.g. `Buy`, `Sell`, `Swap`, `SwapBaseIn` |
+| `outer_program` | string | Top-level program (e.g. Jupiter aggregator) |
+| `inner_program` | string | Actual DEX program that executed the swap |
+| `pool_address` | string | AMM/CLMM pool address |
+| `signer` | string | Transaction fee payer |
+| `token_bought_mint` | string | Mint of token received |
+| `token_bought_vault` | string | Pool vault for bought token |
+| `token_bought_amount` | double | Amount received (decimal-adjusted) |
+| `token_bought_decimals` | uint32 | Decimals for bought token |
+| `token_bought_vault_reserve` | double | Pool reserve after swap |
+| `token_sold_mint` | string | Mint of token sent |
+| `token_sold_vault` | string | Pool vault for sold token |
+| `token_sold_amount` | double | Amount sent (decimal-adjusted) |
+| `token_sold_decimals` | uint32 | Decimals for sold token |
+| `token_sold_vault_reserve` | double | Pool reserve after swap |
+| `txn_fee` | double | Total transaction fee (SOL) |
+| `priority_fee` | double | Priority fee portion (SOL) |
+| `jito_tips` | double | Jito tip amount (SOL) |
+| `sqrt_price` | string | CLMM sqrt price (u128 string, empty for AMMs) |
+| `has_direction` | bool | Whether `is_base_to_quote` is meaningful |
+| `is_base_to_quote` | bool | Trade direction for CLMM pools |
+| `compute_units_consumed` | uint64 | CU used by the transaction |
+
+Token convention: `token_bought` = what the user received, `token_sold` = what the user sent.
+
+## Usage
+
+### As a built-in plugin
+
+```bash
+JETSTREAMER_CLICKHOUSE_MODE=off JETSTREAMER_THREADS=4 \
+  cargo run --release -- --with-plugin dex-trades 280000000:280001000
+```
+
+### With decoded output dump
+
+Set `DEX_TRADES_DUMP=1` to print every decoded swap to stdout:
+
+```bash
+DEX_TRADES_DUMP=1 JETSTREAMER_CLICKHOUSE_MODE=off JETSTREAMER_THREADS=1 \
+  cargo run --release -- --with-plugin dex-trades 280000000:280000010
+```
+
+### As a library
+
+```rust
+use jetstreamer_dex_trades::{DexTradesPlugin, DexRegistry};
+
+// Plugin mode — attach to JetstreamerRunner
+JetstreamerRunner::new()
+    .with_plugin(Box::new(DexTradesPlugin::new()))
+    .parse_cli_args().unwrap()
+    .run().unwrap();
+
+// Library mode — decode transactions directly
+let registry = DexRegistry::new();
+let swaps: Vec<SwapRecord> = registry.decode_transaction(&tx_data, block_time);
+```
+
+### With batch callback
+
+```rust
+let plugin = DexTradesPlugin::with_batch_callback(|slot, protobuf_bytes| {
+    // Write to file, send over network, etc.
+    std::fs::write(format!("slot_{slot}.pb"), &protobuf_bytes).unwrap();
+});
+```
+
+## Decoding Strategies
+
+Decoders use three approaches depending on the DEX:
+
+1. **Event-based** — Parse Anchor self-CPI events from `Program data:` logs (Orca Whirlpool, Raydium CLMM/CPMM, Meteora DLMM/DAMM V2, etc.)
+2. **Log-based** — Parse custom log prefixes like `ray_log:` (Raydium AMM V4)
+3. **Transfer-based** — Infer swaps from SPL Token / Token-2022 transfers in inner instructions (Orca V2, Lifinity, Stabble, smaller DEXes)

--- a/jetstreamer-dex-trades/build.rs
+++ b/jetstreamer-dex-trades/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    prost_build::compile_protos(&["proto/dex_trades.proto"], &["proto/"])?;
+    Ok(())
+}

--- a/jetstreamer-dex-trades/proto/dex_trades.proto
+++ b/jetstreamer-dex-trades/proto/dex_trades.proto
@@ -1,0 +1,67 @@
+syntax = "proto3";
+
+package dex_trades;
+
+// Unified swap record for all Solana DEX protocols.
+//
+// Token convention:
+//   token_bought = what the user received (output of swap)
+//   token_sold   = what the user sent (input to swap)
+message SwapRecord {
+  // Block identity
+  uint64 block_slot = 1;
+  int64  block_time = 2;   // Unix seconds
+  string block_date = 3;   // YYYY-MM-DD (partition key)
+
+  // Transaction identity
+  string tx_id    = 4;     // base58 signature
+  uint32 tx_index = 5;     // index within the block
+
+  // Instruction identity
+  uint32 instruction_index       = 6;  // outer instruction index (1-based)
+  uint32 inner_instruction_index = 7;  // inner index (1-based, 0 if outer)
+  bool   is_inner_instruction    = 8;
+  string instruction_type        = 9;  // e.g. "buy", "sell", "swap"
+
+  // Program identity
+  string outer_program = 10;
+  string inner_program = 11;
+
+  // Pool & signer
+  string pool_address = 12;
+  string signer       = 13;
+
+  // Token bought (user received)
+  string token_bought_mint          = 14;
+  string token_bought_vault         = 15;
+  double token_bought_amount        = 16; // human-readable (decimal-adjusted)
+  uint32 token_bought_decimals      = 17;
+  double token_bought_vault_reserve = 18;
+
+  // Token sold (user sent)
+  string token_sold_mint          = 19;
+  string token_sold_vault         = 20;
+  double token_sold_amount        = 21;
+  double token_sold_vault_reserve = 22;
+  uint32 token_sold_decimals      = 23;
+
+  // Fees (in SOL)
+  double txn_fee      = 24;
+  double priority_fee = 25;
+  double jito_tips    = 26;
+
+  // CLMM-specific pool state
+  string sqrt_price       = 27; // raw u128 string, empty for AMMs
+  bool   has_direction    = 28; // true if is_base_to_quote is meaningful
+  bool   is_base_to_quote = 29; // trade direction for CLMM sqrt_price
+
+  // Compute
+  uint64 compute_units_consumed = 30;
+}
+
+// Batch of swap records, typically one per slot.
+message DexTradesBatch {
+  uint64 slot = 1;
+  int64  block_time = 2;
+  repeated SwapRecord records = 3;
+}

--- a/jetstreamer-dex-trades/src/decoders/alphaq/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/alphaq/mod.rs
@@ -1,0 +1,93 @@
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "ALPHAQmeA7bjrVuccPsYPiCvsi428SNwte66Srvs4pHA";
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub struct AlphaQDecoder;
+
+impl AlphaQDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AlphaQDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for AlphaQDecoder {
+    fn name(&self) -> &'static str {
+        "AlphaQ"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 || data[..8] != SWAP_DISC {
+            return None;
+        }
+
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+        let pool_address = accounts.first().cloned().unwrap_or_default();
+        let vault_a = accounts.get(3).cloned().unwrap_or_default();
+        let vault_b = accounts.get(4).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+        let swap = get_swap_amounts(
+            tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false,
+        )?;
+
+        let vault_a_reserve = get_token_account_info(tx, &vault_a)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        let vault_b_reserve = get_token_account_info(tx, &vault_b)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "Swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool_address;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+        record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
+            vault_a_reserve
+        } else {
+            vault_b_reserve
+        };
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
+            vault_a_reserve
+        } else {
+            vault_b_reserve
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/alphaq/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/alphaq/mod.rs
@@ -48,9 +48,7 @@ impl DexDecoder for AlphaQDecoder {
 
         let outer_idx = ix.instruction_index() as usize;
         let inner_idx = ix.inner_instruction_index() as usize;
-        let swap = get_swap_amounts(
-            tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false,
-        )?;
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
 
         let vault_a_reserve = get_token_account_info(tx, &vault_a)
             .map(|i| i.post_balance_scaled())

--- a/jetstreamer-dex-trades/src/decoders/aquifer/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/aquifer/mod.rs
@@ -47,9 +47,7 @@ impl DexDecoder for AquiferDecoder {
 
         let outer_idx = ix.instruction_index() as usize;
         let inner_idx = ix.inner_instruction_index() as usize;
-        let swap = get_swap_amounts(
-            tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false,
-        )?;
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
 
         let vault_a_reserve = get_token_account_info(tx, &vault_a)
             .map(|i| i.post_balance_scaled())

--- a/jetstreamer-dex-trades/src/decoders/aquifer/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/aquifer/mod.rs
@@ -1,0 +1,92 @@
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "AQU1FRd7papthgdrwPTTq5JacJh8YtwEXaBfKU3bTz45";
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub struct AquiferDecoder;
+
+impl AquiferDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for AquiferDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for AquiferDecoder {
+    fn name(&self) -> &'static str {
+        "Aquifer"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 || data[..8] != SWAP_DISC {
+            return None;
+        }
+
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+        let vault_a = accounts.get(3).cloned().unwrap_or_default();
+        let vault_b = accounts.get(4).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+        let swap = get_swap_amounts(
+            tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false,
+        )?;
+
+        let vault_a_reserve = get_token_account_info(tx, &vault_a)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        let vault_b_reserve = get_token_account_info(tx, &vault_b)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "Swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = String::new();
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+        record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
+            vault_a_reserve
+        } else {
+            vault_b_reserve
+        };
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
+            vault_a_reserve
+        } else {
+            vault_b_reserve
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/bisonfi/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/bisonfi/mod.rs
@@ -48,9 +48,7 @@ impl DexDecoder for BisonFiDecoder {
 
         let outer_idx = ix.instruction_index() as usize;
         let inner_idx = ix.inner_instruction_index() as usize;
-        let swap = get_swap_amounts(
-            tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false,
-        )?;
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
 
         let vault_a_reserve = get_token_account_info(tx, &vault_a)
             .map(|i| i.post_balance_scaled())

--- a/jetstreamer-dex-trades/src/decoders/bisonfi/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/bisonfi/mod.rs
@@ -1,0 +1,93 @@
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "BiSoNHVpsVZW2F7rx2eQ59yQwKxzU5NvBcmKshCSUypi";
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub struct BisonFiDecoder;
+
+impl BisonFiDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for BisonFiDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for BisonFiDecoder {
+    fn name(&self) -> &'static str {
+        "BisonFi"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 || data[..8] != SWAP_DISC {
+            return None;
+        }
+
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+        let pool_address = accounts.first().cloned().unwrap_or_default();
+        let vault_a = accounts.get(3).cloned().unwrap_or_default();
+        let vault_b = accounts.get(4).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+        let swap = get_swap_amounts(
+            tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false,
+        )?;
+
+        let vault_a_reserve = get_token_account_info(tx, &vault_a)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        let vault_b_reserve = get_token_account_info(tx, &vault_b)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "Swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool_address;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+        record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
+            vault_a_reserve
+        } else {
+            vault_b_reserve
+        };
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
+            vault_a_reserve
+        } else {
+            vault_b_reserve
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/byreal_clmm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/byreal_clmm/idl.rs
@@ -1,0 +1,19 @@
+use borsh::BorshDeserialize;
+
+/// SwapEvent emitted by CLMM programs (Byreal, PancakeSwap, Raydium CLMM).
+/// Borsh-serialized after the 8-byte Anchor event discriminator.
+#[derive(Debug, Clone, BorshDeserialize)]
+pub struct SwapEvent {
+    pub pool_state: [u8; 32],
+    pub sender: [u8; 32],
+    pub token_account_0: [u8; 32],
+    pub token_account_1: [u8; 32],
+    pub amount_0: u64,
+    pub transfer_fee_0: u64,
+    pub amount_1: u64,
+    pub transfer_fee_1: u64,
+    pub zero_for_one: bool,
+    pub sqrt_price_x64: u128,
+    pub liquidity: u128,
+    pub tick: i32,
+}

--- a/jetstreamer-dex-trades/src/decoders/byreal_clmm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/byreal_clmm/mod.rs
@@ -1,0 +1,230 @@
+pub mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::log_parser::LogParser;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use crate::registry::DexDecoder;
+use borsh::BorshDeserialize;
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+
+const PROGRAM_ID: &str = "REALQqNEomY6cQGZJUGwywTBD2UmDT32rZcNnfxQ5N2";
+
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+const SWAP_V2_DISC: [u8; 8] = [43, 4, 237, 11, 26, 201, 30, 98];
+
+/// Anchor self-CPI event wrapper discriminator.
+const EVENT_WRAPPER_DISC: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+
+pub struct ByrealClmmDecoder;
+
+impl DexDecoder for ByrealClmmDecoder {
+    fn name(&self) -> &'static str {
+        "Byreal CLMM"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let accounts = ix.accounts();
+
+        let instruction_type = if ix.has_discriminator(&SWAP_DISC) {
+            "Swap"
+        } else if ix.has_discriminator(&SWAP_V2_DISC) {
+            "SwapV2"
+        } else {
+            return try_decode_event(tx, ix, outer_program);
+        };
+
+        if accounts.len() < 2 {
+            return None;
+        }
+
+        let pool = accounts[1].to_string();
+
+        if let Some(record) = try_decode_from_logs(tx, ix, outer_program, &pool, instruction_type) {
+            return Some(record);
+        }
+
+        decode_from_transfers(tx, ix, outer_program, &pool, instruction_type)
+    }
+}
+
+fn try_decode_event(
+    tx: &TransactionData,
+    ix: &Instruction,
+    outer_program: &str,
+) -> Option<SwapRecord> {
+    let data = ix.data();
+    if data.len() < 16 {
+        return None;
+    }
+    if data[..8] != EVENT_WRAPPER_DISC {
+        return None;
+    }
+
+    let event = idl::SwapEvent::try_from_slice(&data[8..]).ok()?;
+    build_record_from_event(tx, ix, outer_program, &event)
+}
+
+fn try_decode_from_logs(
+    tx: &TransactionData,
+    ix: &Instruction,
+    outer_program: &str,
+    _pool: &str,
+    instruction_type: &str,
+) -> Option<SwapRecord> {
+    let logs = tx.get_logs();
+    let data_events = LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
+
+    let position = if ix.is_inner() {
+        format!(
+            "{}.{}",
+            ix.instruction_index(),
+            ix.inner_instruction_index()
+        )
+    } else {
+        ix.instruction_index().to_string()
+    };
+
+    let event_data_list = data_events.get(&position)?;
+
+    for encoded in event_data_list {
+        if let Ok(raw) = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encoded)
+        {
+            if raw.len() < 8 {
+                continue;
+            }
+            if let Ok(event) = idl::SwapEvent::try_from_slice(&raw[8..]) {
+                let pool_addr = Address::new_from_array(event.pool_state);
+                let mut record = build_record_from_event(tx, ix, outer_program, &event)?;
+                record.pool_address = pool_addr.to_string();
+                record.instruction_type = instruction_type.to_string();
+                return Some(record);
+            }
+        }
+    }
+
+    None
+}
+
+fn decode_from_transfers(
+    tx: &TransactionData,
+    ix: &Instruction,
+    outer_program: &str,
+    pool: &str,
+    instruction_type: &str,
+) -> Option<SwapRecord> {
+    let accounts = ix.accounts();
+    if accounts.len() < 10 {
+        return None;
+    }
+
+    let vault_0 = accounts[4].to_string();
+    let vault_1 = accounts[5].to_string();
+
+    let outer_idx = ix.instruction_index() as usize;
+    let inner_idx = ix.inner_instruction_index() as usize;
+
+    let amounts = get_swap_amounts(tx, outer_idx, inner_idx, &vault_0, &vault_1, None, false)?;
+
+    let mut record = SwapRecord::default();
+    record.instruction_index = ix.instruction_index();
+    record.inner_instruction_index = ix.inner_instruction_index();
+    record.is_inner_instruction = ix.is_inner();
+    record.instruction_type = instruction_type.to_string();
+    record.outer_program = outer_program.to_string();
+    record.inner_program = PROGRAM_ID.to_string();
+    record.pool_address = pool.to_string();
+
+    record.token_sold_mint = amounts.sold.mint.clone();
+    record.token_sold_vault = amounts.sold.vault.clone();
+    record.token_sold_amount = amounts.sold.amount_scaled();
+    record.token_sold_decimals = amounts.sold.decimals;
+
+    record.token_bought_mint = amounts.bought.mint.clone();
+    record.token_bought_vault = amounts.bought.vault.clone();
+    record.token_bought_amount = amounts.bought.amount_scaled();
+    record.token_bought_decimals = amounts.bought.decimals;
+
+    let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
+    let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
+    record.token_sold_vault_reserve =
+        sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+    record.token_bought_vault_reserve =
+        bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+
+    Some(record)
+}
+
+fn build_record_from_event(
+    tx: &TransactionData,
+    ix: &Instruction,
+    outer_program: &str,
+    event: &idl::SwapEvent,
+) -> Option<SwapRecord> {
+    let pool = Address::new_from_array(event.pool_state);
+    let vault_0 = Address::new_from_array(event.token_account_0);
+    let vault_1 = Address::new_from_array(event.token_account_1);
+
+    let info_0 = get_token_account_info(tx, &vault_0.to_string());
+    let info_1 = get_token_account_info(tx, &vault_1.to_string());
+
+    let decimals_0 = info_0.as_ref().map(|i| i.decimals).unwrap_or(6);
+    let decimals_1 = info_1.as_ref().map(|i| i.decimals).unwrap_or(6);
+    let mint_0 = info_0.as_ref().map(|i| i.mint.clone()).unwrap_or_default();
+    let mint_1 = info_1.as_ref().map(|i| i.mint.clone()).unwrap_or_default();
+
+    let amount_0 = event.amount_0 as f64 / 10f64.powi(decimals_0 as i32);
+    let amount_1 = event.amount_1 as f64 / 10f64.powi(decimals_1 as i32);
+
+    let mut record = SwapRecord::default();
+    record.instruction_index = ix.instruction_index();
+    record.inner_instruction_index = ix.inner_instruction_index();
+    record.is_inner_instruction = ix.is_inner();
+    record.instruction_type = "Swap".to_string();
+    record.outer_program = outer_program.to_string();
+    record.inner_program = PROGRAM_ID.to_string();
+    record.pool_address = pool.to_string();
+
+    record.sqrt_price = event.sqrt_price_x64.to_string();
+    record.is_base_to_quote = Some(event.zero_for_one);
+
+    if event.zero_for_one {
+        record.token_sold_mint = mint_0;
+        record.token_sold_vault = vault_0.to_string();
+        record.token_sold_amount = amount_0;
+        record.token_sold_decimals = decimals_0;
+        record.token_bought_mint = mint_1;
+        record.token_bought_vault = vault_1.to_string();
+        record.token_bought_amount = amount_1;
+        record.token_bought_decimals = decimals_1;
+    } else {
+        record.token_sold_mint = mint_1;
+        record.token_sold_vault = vault_1.to_string();
+        record.token_sold_amount = amount_1;
+        record.token_sold_decimals = decimals_1;
+        record.token_bought_mint = mint_0;
+        record.token_bought_vault = vault_0.to_string();
+        record.token_bought_amount = amount_0;
+        record.token_bought_decimals = decimals_0;
+    }
+
+    let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
+    let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
+    record.token_sold_vault_reserve =
+        sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+    record.token_bought_vault_reserve =
+        bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+
+    Some(record)
+}

--- a/jetstreamer-dex-trades/src/decoders/byreal_clmm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/byreal_clmm/mod.rs
@@ -2,10 +2,10 @@ pub mod idl;
 
 use crate::instruction_iter::Instruction;
 use crate::log_parser::LogParser;
+use crate::registry::DexDecoder;
 use crate::token_transfers::{get_swap_amounts, get_token_account_info};
 use crate::transaction_ext::TransactionExt;
 use crate::types::SwapRecord;
-use crate::registry::DexDecoder;
 use borsh::BorshDeserialize;
 use jetstreamer_firehose::firehose::TransactionData;
 use solana_address::Address;
@@ -158,10 +158,12 @@ fn decode_from_transfers(
 
     let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
     let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
-    record.token_sold_vault_reserve =
-        sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
-    record.token_bought_vault_reserve =
-        bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+    record.token_sold_vault_reserve = sold_vault_info
+        .map(|i| i.post_balance_scaled())
+        .unwrap_or(0.0);
+    record.token_bought_vault_reserve = bought_vault_info
+        .map(|i| i.post_balance_scaled())
+        .unwrap_or(0.0);
 
     Some(record)
 }
@@ -221,10 +223,12 @@ fn build_record_from_event(
 
     let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
     let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
-    record.token_sold_vault_reserve =
-        sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
-    record.token_bought_vault_reserve =
-        bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+    record.token_sold_vault_reserve = sold_vault_info
+        .map(|i| i.post_balance_scaled())
+        .unwrap_or(0.0);
+    record.token_bought_vault_reserve = bought_vault_info
+        .map(|i| i.post_balance_scaled())
+        .unwrap_or(0.0);
 
     Some(record)
 }

--- a/jetstreamer-dex-trades/src/decoders/futarchy_amm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/futarchy_amm/idl.rs
@@ -28,7 +28,7 @@ impl SwapType {
         match val {
             0 => Some(Self::Buy),
             1 => Some(Self::Sell),
-        _ => None,
+            _ => None,
         }
     }
 

--- a/jetstreamer-dex-trades/src/decoders/futarchy_amm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/futarchy_amm/idl.rs
@@ -1,0 +1,209 @@
+use byteorder::{LittleEndian, ReadBytesExt};
+use solana_address::Address;
+use std::io::{Cursor, Read};
+
+const PUBKEY_LEN: usize = 32;
+
+pub const EVENT_WRAPPER_DISC: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+pub const SPOT_SWAP_EVENT_DISC: [u8; 8] = [29, 253, 121, 255, 82, 60, 148, 195];
+pub const CONDITIONAL_SWAP_EVENT_DISC: [u8; 8] = [2, 166, 200, 160, 94, 212, 68, 45];
+
+pub const SPOT_SWAP_DISC: [u8; 8] = [167, 97, 12, 231, 237, 78, 166, 251];
+pub const CONDITIONAL_SWAP_DISC: [u8; 8] = [194, 136, 220, 89, 242, 169, 130, 157];
+
+fn read_pubkey(cursor: &mut Cursor<&[u8]>) -> Option<[u8; 32]> {
+    let mut buf = [0u8; PUBKEY_LEN];
+    cursor.read_exact(&mut buf).ok()?;
+    Some(buf)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SwapType {
+    Buy = 0,
+    Sell = 1,
+}
+
+impl SwapType {
+    pub fn from_u8(val: u8) -> Option<Self> {
+        match val {
+            0 => Some(Self::Buy),
+            1 => Some(Self::Sell),
+        _ => None,
+        }
+    }
+
+    pub fn label(&self) -> &'static str {
+        match self {
+            Self::Buy => "Buy",
+            Self::Sell => "Sell",
+        }
+    }
+}
+
+/// On-chain FutarchyAmm state — only the fields we need for decoding.
+#[derive(Debug, Clone)]
+pub struct FutarchyAmm {
+    pub base_mint: Address,
+    pub quote_mint: Address,
+    pub amm_base_vault: Address,
+    pub amm_quote_vault: Address,
+}
+
+/// Pool state variants embedded in events.
+/// Spot: 1 pool (132 bytes), Futarchy: 3 pools (396 bytes).
+#[derive(Debug, Clone)]
+pub enum PoolState {
+    Spot(FutarchyAmm),
+    Futarchy([FutarchyAmm; 3]),
+}
+
+impl FutarchyAmm {
+    /// Deserialize a single pool from 132 bytes:
+    /// state_variant(u8) + total_liquidity(u128=16) + padding(3) +
+    /// base_mint(32) + quote_mint(32) + amm_base_vault(32) + amm_quote_vault(32) = ~148
+    /// Simplified layout: skip state_variant(1) + total_liquidity(16) = 17 prefix,
+    /// then base_mint(32) + quote_mint(32) + amm_base_vault(32) + amm_quote_vault(32) = 128
+    pub fn deserialize(data: &[u8]) -> Option<Self> {
+        if data.len() < 132 {
+            return None;
+        }
+        let mut cursor = Cursor::new(data);
+
+        // state_variant: u8
+        let _state_variant = cursor.read_u8().ok()?;
+        // total_liquidity: u128
+        let _total_liquidity = cursor.read_u128::<LittleEndian>().ok()?;
+        // padding: 3 bytes
+        let mut _pad = [0u8; 3];
+        cursor.read_exact(&mut _pad).ok()?;
+
+        let base_mint = Address::new_from_array(read_pubkey(&mut cursor)?);
+        let quote_mint = Address::new_from_array(read_pubkey(&mut cursor)?);
+        let amm_base_vault = Address::new_from_array(read_pubkey(&mut cursor)?);
+        let amm_quote_vault = Address::new_from_array(read_pubkey(&mut cursor)?);
+
+        Some(Self {
+            base_mint,
+            quote_mint,
+            amm_base_vault,
+            amm_quote_vault,
+        })
+    }
+}
+
+/// SpotSwapEvent emitted by Futarchy AMM via Anchor self-CPI.
+#[derive(Debug, Clone)]
+pub struct SpotSwapEvent {
+    pub dao: [u8; 32],
+    pub user: [u8; 32],
+    pub swap_type: SwapType,
+    pub input_amount: u64,
+    pub output_amount: u64,
+    pub post_amm_state: FutarchyAmm,
+}
+
+impl SpotSwapEvent {
+    /// Layout: dao(32) + user(32) + swap_type(1) + input_amount(8) + output_amount(8) +
+    /// post_amm_state(132) = 213 bytes
+    pub fn deserialize(data: &[u8]) -> Option<Self> {
+        if data.len() < 213 {
+            return None;
+        }
+        let mut cursor = Cursor::new(data);
+
+        let dao = read_pubkey(&mut cursor)?;
+        let user = read_pubkey(&mut cursor)?;
+        let swap_type_byte = cursor.read_u8().ok()?;
+        let swap_type = SwapType::from_u8(swap_type_byte)?;
+        let input_amount = cursor.read_u64::<LittleEndian>().ok()?;
+        let output_amount = cursor.read_u64::<LittleEndian>().ok()?;
+
+        let pos = cursor.position() as usize;
+        let post_amm_state = FutarchyAmm::deserialize(&data[pos..])?;
+
+        Some(Self {
+            dao,
+            user,
+            swap_type,
+            input_amount,
+            output_amount,
+            post_amm_state,
+        })
+    }
+}
+
+/// ConditionalSwapEvent emitted by Futarchy AMM via Anchor self-CPI.
+#[derive(Debug, Clone)]
+pub struct ConditionalSwapEvent {
+    pub dao: [u8; 32],
+    pub user: [u8; 32],
+    pub swap_type: SwapType,
+    pub input_amount: u64,
+    pub output_amount: u64,
+    pub post_amm_state: [FutarchyAmm; 3],
+}
+
+impl ConditionalSwapEvent {
+    /// Layout: dao(32) + user(32) + swap_type(1) + input_amount(8) + output_amount(8) +
+    /// post_amm_state(3 * 132 = 396) = 477 bytes
+    pub fn deserialize(data: &[u8]) -> Option<Self> {
+        if data.len() < 477 {
+            return None;
+        }
+        let mut cursor = Cursor::new(data);
+
+        let dao = read_pubkey(&mut cursor)?;
+        let user = read_pubkey(&mut cursor)?;
+        let swap_type_byte = cursor.read_u8().ok()?;
+        let swap_type = SwapType::from_u8(swap_type_byte)?;
+        let input_amount = cursor.read_u64::<LittleEndian>().ok()?;
+        let output_amount = cursor.read_u64::<LittleEndian>().ok()?;
+
+        let pos = cursor.position() as usize;
+        let pool0 = FutarchyAmm::deserialize(&data[pos..])?;
+        let pool1 = FutarchyAmm::deserialize(&data[pos + 132..])?;
+        let pool2 = FutarchyAmm::deserialize(&data[pos + 264..])?;
+
+        Some(Self {
+            dao,
+            user,
+            swap_type,
+            input_amount,
+            output_amount,
+            post_amm_state: [pool0, pool1, pool2],
+        })
+    }
+}
+
+pub mod events {
+    use super::*;
+
+    pub enum FutarchyEvent {
+        SpotSwap(SpotSwapEvent),
+        ConditionalSwap(ConditionalSwapEvent),
+    }
+
+    /// Decode a Futarchy event from Anchor self-CPI instruction data.
+    /// Layout: event_wrapper_disc(8) + inner_event_disc(8) + payload.
+    pub fn decode_event(data: &[u8]) -> Option<FutarchyEvent> {
+        if data.len() < 16 {
+            return None;
+        }
+        if data[..8] != EVENT_WRAPPER_DISC {
+            return None;
+        }
+
+        let inner_disc = &data[8..16];
+        let payload = &data[16..];
+
+        if inner_disc == SPOT_SWAP_EVENT_DISC {
+            let event = SpotSwapEvent::deserialize(payload)?;
+            Some(FutarchyEvent::SpotSwap(event))
+        } else if inner_disc == CONDITIONAL_SWAP_EVENT_DISC {
+            let event = ConditionalSwapEvent::deserialize(payload)?;
+            Some(FutarchyEvent::ConditionalSwap(event))
+        } else {
+            None
+        }
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/futarchy_amm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/futarchy_amm/mod.rs
@@ -1,0 +1,272 @@
+pub mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::token_transfers::get_token_account_info;
+use crate::types::SwapRecord;
+use crate::registry::DexDecoder;
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+const PROGRAM_ID: &str = "FUTARELBfJfQ8RDGhg1wdhddq1odMAJUePHFuBYfUxKq";
+
+/// Cached context for an instruction within a transaction.
+#[derive(Debug, Clone)]
+struct InstructionContext {
+    pool: String,
+    instruction_type: String,
+}
+
+pub struct FutarchyAmmDecoder {
+    context_cache: RwLock<HashMap<String, Vec<InstructionContext>>>,
+}
+
+impl FutarchyAmmDecoder {
+    pub fn new() -> Self {
+        Self {
+            context_cache: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl DexDecoder for FutarchyAmmDecoder {
+    fn name(&self) -> &'static str {
+        "Futarchy AMM"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn on_transaction_start(&self, tx: &TransactionData) {
+        let tx_id = tx.signature.to_string();
+        let mut contexts = Vec::new();
+
+        for ix in crate::instruction_iter::InstructionIteratorExt::all_instructions(tx) {
+            if ix.program_id().to_string() != PROGRAM_ID {
+                continue;
+            }
+
+            let data = ix.data();
+            let accounts = ix.accounts();
+
+            if ix.has_discriminator(&idl::SPOT_SWAP_DISC) {
+                let pool = accounts.first().map(|a| a.to_string()).unwrap_or_default();
+                contexts.push(InstructionContext {
+                    pool,
+                    instruction_type: "spotSwap".to_string(),
+                });
+            } else if ix.has_discriminator(&idl::CONDITIONAL_SWAP_DISC) {
+                let pool = accounts.first().map(|a| a.to_string()).unwrap_or_default();
+                contexts.push(InstructionContext {
+                    pool,
+                    instruction_type: "conditionalSwap".to_string(),
+                });
+            }
+
+            let _ = data;
+        }
+
+        if !contexts.is_empty() {
+            if let Ok(mut cache) = self.context_cache.write() {
+                cache.insert(tx_id, contexts);
+            }
+        }
+    }
+
+    fn on_transaction_end(&self, tx_id: &str) {
+        if let Ok(mut cache) = self.context_cache.write() {
+            cache.remove(tx_id);
+        }
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+
+        let event = idl::events::decode_event(data)?;
+
+        match event {
+            idl::events::FutarchyEvent::SpotSwap(e) => {
+                self.decode_spot_swap(tx, ix, outer_program, &e)
+            }
+            idl::events::FutarchyEvent::ConditionalSwap(e) => {
+                self.decode_conditional_swap(tx, ix, outer_program, &e)
+            }
+        }
+    }
+}
+
+impl FutarchyAmmDecoder {
+    fn get_instruction_context(&self, tx_id: &str, ix_type: &str) -> Option<InstructionContext> {
+        let cache = self.context_cache.read().ok()?;
+        let contexts = cache.get(tx_id)?;
+        contexts
+            .iter()
+            .find(|ctx| ctx.instruction_type == ix_type)
+            .cloned()
+    }
+
+    fn decode_spot_swap(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        event: &idl::SpotSwapEvent,
+    ) -> Option<SwapRecord> {
+        let tx_id = tx.signature.to_string();
+        let dao = Address::new_from_array(event.dao);
+        let user = Address::new_from_array(event.user);
+        let amm = &event.post_amm_state;
+
+        let pool = self
+            .get_instruction_context(&tx_id, "spotSwap")
+            .map(|ctx| ctx.pool)
+            .unwrap_or_else(|| dao.to_string());
+
+        let base_mint = amm.base_mint.to_string();
+        let quote_mint = amm.quote_mint.to_string();
+        let base_vault = amm.amm_base_vault.to_string();
+        let quote_vault = amm.amm_quote_vault.to_string();
+
+        let base_info = get_token_account_info(tx, &base_vault);
+        let quote_info = get_token_account_info(tx, &quote_vault);
+
+        let base_decimals = base_info.as_ref().map(|i| i.decimals).unwrap_or(6);
+        let quote_decimals = quote_info.as_ref().map(|i| i.decimals).unwrap_or(6);
+
+        let input_scaled = event.input_amount as f64 / 10f64.powi(
+            if event.swap_type == idl::SwapType::Buy { quote_decimals } else { base_decimals } as i32
+        );
+        let output_scaled = event.output_amount as f64 / 10f64.powi(
+            if event.swap_type == idl::SwapType::Buy { base_decimals } else { quote_decimals } as i32
+        );
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = format!("spotSwap{}", event.swap_type.label());
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+        record.signer = user.to_string();
+
+        match event.swap_type {
+            idl::SwapType::Buy => {
+                record.token_bought_mint = base_mint;
+                record.token_bought_vault = base_vault;
+                record.token_bought_amount = output_scaled;
+                record.token_bought_decimals = base_decimals;
+                record.token_sold_mint = quote_mint;
+                record.token_sold_vault = quote_vault;
+                record.token_sold_amount = input_scaled;
+                record.token_sold_decimals = quote_decimals;
+            }
+            idl::SwapType::Sell => {
+                record.token_bought_mint = quote_mint;
+                record.token_bought_vault = quote_vault;
+                record.token_bought_amount = output_scaled;
+                record.token_bought_decimals = quote_decimals;
+                record.token_sold_mint = base_mint;
+                record.token_sold_vault = base_vault;
+                record.token_sold_amount = input_scaled;
+                record.token_sold_decimals = base_decimals;
+            }
+        }
+
+        let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
+        let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
+        record.token_sold_vault_reserve =
+            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_bought_vault_reserve =
+            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+
+        Some(record)
+    }
+
+    fn decode_conditional_swap(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        event: &idl::ConditionalSwapEvent,
+    ) -> Option<SwapRecord> {
+        let tx_id = tx.signature.to_string();
+        let dao = Address::new_from_array(event.dao);
+        let user = Address::new_from_array(event.user);
+
+        let pool = self
+            .get_instruction_context(&tx_id, "conditionalSwap")
+            .map(|ctx| ctx.pool)
+            .unwrap_or_else(|| dao.to_string());
+
+        // Use first pool in the array for mint/vault info
+        let amm = &event.post_amm_state[0];
+
+        let base_mint = amm.base_mint.to_string();
+        let quote_mint = amm.quote_mint.to_string();
+        let base_vault = amm.amm_base_vault.to_string();
+        let quote_vault = amm.amm_quote_vault.to_string();
+
+        let base_info = get_token_account_info(tx, &base_vault);
+        let quote_info = get_token_account_info(tx, &quote_vault);
+
+        let base_decimals = base_info.as_ref().map(|i| i.decimals).unwrap_or(6);
+        let quote_decimals = quote_info.as_ref().map(|i| i.decimals).unwrap_or(6);
+
+        let input_scaled = event.input_amount as f64 / 10f64.powi(
+            if event.swap_type == idl::SwapType::Buy { quote_decimals } else { base_decimals } as i32
+        );
+        let output_scaled = event.output_amount as f64 / 10f64.powi(
+            if event.swap_type == idl::SwapType::Buy { base_decimals } else { quote_decimals } as i32
+        );
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = format!("conditionalSwap{}", event.swap_type.label());
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+        record.signer = user.to_string();
+
+        match event.swap_type {
+            idl::SwapType::Buy => {
+                record.token_bought_mint = base_mint;
+                record.token_bought_vault = base_vault;
+                record.token_bought_amount = output_scaled;
+                record.token_bought_decimals = base_decimals;
+                record.token_sold_mint = quote_mint;
+                record.token_sold_vault = quote_vault;
+                record.token_sold_amount = input_scaled;
+                record.token_sold_decimals = quote_decimals;
+            }
+            idl::SwapType::Sell => {
+                record.token_bought_mint = quote_mint;
+                record.token_bought_vault = quote_vault;
+                record.token_bought_amount = output_scaled;
+                record.token_bought_decimals = quote_decimals;
+                record.token_sold_mint = base_mint;
+                record.token_sold_vault = base_vault;
+                record.token_sold_amount = input_scaled;
+                record.token_sold_decimals = base_decimals;
+            }
+        }
+
+        let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
+        let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
+        record.token_sold_vault_reserve =
+            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_bought_vault_reserve =
+            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/futarchy_amm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/futarchy_amm/mod.rs
@@ -1,9 +1,9 @@
 pub mod idl;
 
 use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
 use crate::token_transfers::get_token_account_info;
 use crate::types::SwapRecord;
-use crate::registry::DexDecoder;
 use jetstreamer_firehose::firehose::TransactionData;
 use solana_address::Address;
 use std::collections::HashMap;
@@ -20,6 +20,12 @@ struct InstructionContext {
 
 pub struct FutarchyAmmDecoder {
     context_cache: RwLock<HashMap<String, Vec<InstructionContext>>>,
+}
+
+impl Default for FutarchyAmmDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl FutarchyAmmDecoder {
@@ -68,10 +74,10 @@ impl DexDecoder for FutarchyAmmDecoder {
             let _ = data;
         }
 
-        if !contexts.is_empty() {
-            if let Ok(mut cache) = self.context_cache.write() {
-                cache.insert(tx_id, contexts);
-            }
+        if !contexts.is_empty()
+            && let Ok(mut cache) = self.context_cache.write()
+        {
+            cache.insert(tx_id, contexts);
         }
     }
 
@@ -140,12 +146,18 @@ impl FutarchyAmmDecoder {
         let base_decimals = base_info.as_ref().map(|i| i.decimals).unwrap_or(6);
         let quote_decimals = quote_info.as_ref().map(|i| i.decimals).unwrap_or(6);
 
-        let input_scaled = event.input_amount as f64 / 10f64.powi(
-            if event.swap_type == idl::SwapType::Buy { quote_decimals } else { base_decimals } as i32
-        );
-        let output_scaled = event.output_amount as f64 / 10f64.powi(
-            if event.swap_type == idl::SwapType::Buy { base_decimals } else { quote_decimals } as i32
-        );
+        let input_scaled = event.input_amount as f64
+            / 10f64.powi(if event.swap_type == idl::SwapType::Buy {
+                quote_decimals
+            } else {
+                base_decimals
+            } as i32);
+        let output_scaled = event.output_amount as f64
+            / 10f64.powi(if event.swap_type == idl::SwapType::Buy {
+                base_decimals
+            } else {
+                quote_decimals
+            } as i32);
 
         let mut record = SwapRecord::default();
         record.instruction_index = ix.instruction_index();
@@ -182,10 +194,12 @@ impl FutarchyAmmDecoder {
 
         let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
         let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
-        record.token_sold_vault_reserve =
-            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
-        record.token_bought_vault_reserve =
-            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_sold_vault_reserve = sold_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        record.token_bought_vault_reserve = bought_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
 
         Some(record)
     }
@@ -220,12 +234,18 @@ impl FutarchyAmmDecoder {
         let base_decimals = base_info.as_ref().map(|i| i.decimals).unwrap_or(6);
         let quote_decimals = quote_info.as_ref().map(|i| i.decimals).unwrap_or(6);
 
-        let input_scaled = event.input_amount as f64 / 10f64.powi(
-            if event.swap_type == idl::SwapType::Buy { quote_decimals } else { base_decimals } as i32
-        );
-        let output_scaled = event.output_amount as f64 / 10f64.powi(
-            if event.swap_type == idl::SwapType::Buy { base_decimals } else { quote_decimals } as i32
-        );
+        let input_scaled = event.input_amount as f64
+            / 10f64.powi(if event.swap_type == idl::SwapType::Buy {
+                quote_decimals
+            } else {
+                base_decimals
+            } as i32);
+        let output_scaled = event.output_amount as f64
+            / 10f64.powi(if event.swap_type == idl::SwapType::Buy {
+                base_decimals
+            } else {
+                quote_decimals
+            } as i32);
 
         let mut record = SwapRecord::default();
         record.instruction_index = ix.instruction_index();
@@ -262,10 +282,12 @@ impl FutarchyAmmDecoder {
 
         let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
         let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
-        record.token_sold_vault_reserve =
-            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
-        record.token_bought_vault_reserve =
-            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_sold_vault_reserve = sold_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        record.token_bought_vault_reserve = bought_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
 
         Some(record)
     }

--- a/jetstreamer-dex-trades/src/decoders/goonfi/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/goonfi/mod.rs
@@ -73,14 +73,26 @@ impl DexDecoder for GoonfiDecoder {
         record.token_bought_decimals = swap.bought.decimals;
 
         record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
         record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
 
         Some(record)

--- a/jetstreamer-dex-trades/src/decoders/goonfi/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/goonfi/mod.rs
@@ -1,0 +1,88 @@
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "goonERTdGsjnkZqWuVjs73BZ3Pb9qoCUdBUL17BnS5j";
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub struct GoonfiDecoder;
+
+impl GoonfiDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for GoonfiDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for GoonfiDecoder {
+    fn name(&self) -> &'static str {
+        "GoonFi"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 || data[..8] != SWAP_DISC {
+            return None;
+        }
+
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+        let pool = accounts.first().cloned().unwrap_or_default();
+        let vault_a = accounts.get(3).cloned().unwrap_or_default();
+        let vault_b = accounts.get(4).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
+
+        let vault_a_info = get_token_account_info(tx, &vault_a);
+        let vault_b_info = get_token_account_info(tx, &vault_b);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+        record.instruction_type = "Swap".to_string();
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+
+        record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+        record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/humidifi/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/humidifi/mod.rs
@@ -73,14 +73,26 @@ impl DexDecoder for HumidifiDecoder {
         record.token_bought_decimals = swap.bought.decimals;
 
         record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
         record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
 
         Some(record)

--- a/jetstreamer-dex-trades/src/decoders/humidifi/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/humidifi/mod.rs
@@ -1,0 +1,88 @@
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "9H6tua7jkLhdm3w8BvgpTn5LZNU7g4ZynDmCiNN3q6Rp";
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub struct HumidifiDecoder;
+
+impl HumidifiDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for HumidifiDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for HumidifiDecoder {
+    fn name(&self) -> &'static str {
+        "HumidiFi"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 || data[..8] != SWAP_DISC {
+            return None;
+        }
+
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+        let pool = accounts.first().cloned().unwrap_or_default();
+        let vault_a = accounts.get(3).cloned().unwrap_or_default();
+        let vault_b = accounts.get(4).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
+
+        let vault_a_info = get_token_account_info(tx, &vault_a);
+        let vault_b_info = get_token_account_info(tx, &vault_b);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+        record.instruction_type = "Swap".to_string();
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+
+        record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+        record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/lifinity_v1/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/lifinity_v1/mod.rs
@@ -1,0 +1,83 @@
+use crate::instruction_iter::Instruction;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use crate::registry::DexDecoder;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "EewxydAPCCVuNEyrVN68PuSYdQ7wKn27V9Gjeoi8dy3S";
+
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub struct LifinityV1Decoder;
+
+impl DexDecoder for LifinityV1Decoder {
+    fn name(&self) -> &'static str {
+        "Lifinity V1"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let accounts = ix.accounts();
+
+        if !ix.has_discriminator(&SWAP_DISC) {
+            return None;
+        }
+
+        if accounts.len() < 7 {
+            return None;
+        }
+
+        let pool = accounts[1].to_string();
+        let vault_a = accounts[5].to_string();
+        let vault_b = accounts[6].to_string();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let amounts = get_swap_amounts(
+            tx,
+            outer_idx,
+            inner_idx,
+            &vault_a,
+            &vault_b,
+            None,
+            false,
+        )?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "Swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        record.token_sold_mint = amounts.sold.mint.clone();
+        record.token_sold_vault = amounts.sold.vault.clone();
+        record.token_sold_amount = amounts.sold.amount_scaled();
+        record.token_sold_decimals = amounts.sold.decimals;
+
+        record.token_bought_mint = amounts.bought.mint.clone();
+        record.token_bought_vault = amounts.bought.vault.clone();
+        record.token_bought_amount = amounts.bought.amount_scaled();
+        record.token_bought_decimals = amounts.bought.decimals;
+
+        let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
+        let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
+        record.token_sold_vault_reserve =
+            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_bought_vault_reserve =
+            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/lifinity_v1/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/lifinity_v1/mod.rs
@@ -1,7 +1,7 @@
 use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
 use crate::token_transfers::{get_swap_amounts, get_token_account_info};
 use crate::types::SwapRecord;
-use crate::registry::DexDecoder;
 use jetstreamer_firehose::firehose::TransactionData;
 
 const PROGRAM_ID: &str = "EewxydAPCCVuNEyrVN68PuSYdQ7wKn27V9Gjeoi8dy3S";
@@ -42,15 +42,7 @@ impl DexDecoder for LifinityV1Decoder {
         let outer_idx = ix.instruction_index() as usize;
         let inner_idx = ix.inner_instruction_index() as usize;
 
-        let amounts = get_swap_amounts(
-            tx,
-            outer_idx,
-            inner_idx,
-            &vault_a,
-            &vault_b,
-            None,
-            false,
-        )?;
+        let amounts = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
 
         let mut record = SwapRecord::default();
         record.instruction_index = ix.instruction_index();
@@ -73,10 +65,12 @@ impl DexDecoder for LifinityV1Decoder {
 
         let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
         let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
-        record.token_sold_vault_reserve =
-            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
-        record.token_bought_vault_reserve =
-            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_sold_vault_reserve = sold_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        record.token_bought_vault_reserve = bought_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
 
         Some(record)
     }

--- a/jetstreamer-dex-trades/src/decoders/lifinity_v2/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/lifinity_v2/mod.rs
@@ -1,0 +1,83 @@
+use crate::instruction_iter::Instruction;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use crate::registry::DexDecoder;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "2wT8Yq49kHgDzXuPxZSaeLaH1qbmGXtEyPy64bL7aD3c";
+
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub struct LifinityV2Decoder;
+
+impl DexDecoder for LifinityV2Decoder {
+    fn name(&self) -> &'static str {
+        "Lifinity V2"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let accounts = ix.accounts();
+
+        if !ix.has_discriminator(&SWAP_DISC) {
+            return None;
+        }
+
+        if accounts.len() < 7 {
+            return None;
+        }
+
+        let pool = accounts[1].to_string();
+        let vault_a = accounts[5].to_string();
+        let vault_b = accounts[6].to_string();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let amounts = get_swap_amounts(
+            tx,
+            outer_idx,
+            inner_idx,
+            &vault_a,
+            &vault_b,
+            None,
+            false,
+        )?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "Swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        record.token_sold_mint = amounts.sold.mint.clone();
+        record.token_sold_vault = amounts.sold.vault.clone();
+        record.token_sold_amount = amounts.sold.amount_scaled();
+        record.token_sold_decimals = amounts.sold.decimals;
+
+        record.token_bought_mint = amounts.bought.mint.clone();
+        record.token_bought_vault = amounts.bought.vault.clone();
+        record.token_bought_amount = amounts.bought.amount_scaled();
+        record.token_bought_decimals = amounts.bought.decimals;
+
+        let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
+        let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
+        record.token_sold_vault_reserve =
+            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_bought_vault_reserve =
+            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/lifinity_v2/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/lifinity_v2/mod.rs
@@ -1,7 +1,7 @@
 use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
 use crate::token_transfers::{get_swap_amounts, get_token_account_info};
 use crate::types::SwapRecord;
-use crate::registry::DexDecoder;
 use jetstreamer_firehose::firehose::TransactionData;
 
 const PROGRAM_ID: &str = "2wT8Yq49kHgDzXuPxZSaeLaH1qbmGXtEyPy64bL7aD3c";
@@ -42,15 +42,7 @@ impl DexDecoder for LifinityV2Decoder {
         let outer_idx = ix.instruction_index() as usize;
         let inner_idx = ix.inner_instruction_index() as usize;
 
-        let amounts = get_swap_amounts(
-            tx,
-            outer_idx,
-            inner_idx,
-            &vault_a,
-            &vault_b,
-            None,
-            false,
-        )?;
+        let amounts = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
 
         let mut record = SwapRecord::default();
         record.instruction_index = ix.instruction_index();
@@ -73,10 +65,12 @@ impl DexDecoder for LifinityV2Decoder {
 
         let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
         let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
-        record.token_sold_vault_reserve =
-            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
-        record.token_bought_vault_reserve =
-            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_sold_vault_reserve = sold_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        record.token_bought_vault_reserve = bought_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
 
         Some(record)
     }

--- a/jetstreamer-dex-trades/src/decoders/manifest/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/manifest/mod.rs
@@ -48,9 +48,7 @@ impl DexDecoder for ManifestDecoder {
 
         let outer_idx = ix.instruction_index() as usize;
         let inner_idx = ix.inner_instruction_index() as usize;
-        let swap = get_swap_amounts(
-            tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false,
-        )?;
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
 
         let vault_a_reserve = get_token_account_info(tx, &vault_a)
             .map(|i| i.post_balance_scaled())

--- a/jetstreamer-dex-trades/src/decoders/manifest/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/manifest/mod.rs
@@ -1,0 +1,93 @@
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "MNFSTqtC93rEfYHB6hF82sKdZpUDFWkViLByLd1k1Ms";
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub struct ManifestDecoder;
+
+impl ManifestDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ManifestDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for ManifestDecoder {
+    fn name(&self) -> &'static str {
+        "Manifest"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 || data[..8] != SWAP_DISC {
+            return None;
+        }
+
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+        let pool_address = accounts.first().cloned().unwrap_or_default();
+        let vault_a = accounts.get(3).cloned().unwrap_or_default();
+        let vault_b = accounts.get(4).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+        let swap = get_swap_amounts(
+            tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false,
+        )?;
+
+        let vault_a_reserve = get_token_account_info(tx, &vault_a)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        let vault_b_reserve = get_token_account_info(tx, &vault_b)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "Swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool_address;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+        record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
+            vault_a_reserve
+        } else {
+            vault_b_reserve
+        };
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
+            vault_a_reserve
+        } else {
+            vault_b_reserve
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/meteora_damm_v2/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_damm_v2/idl.rs
@@ -1,0 +1,27 @@
+use borsh::BorshDeserialize;
+use base64::{engine::general_purpose::STANDARD, Engine};
+
+pub const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub const SWAP_EVENT_DISC: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
+
+#[derive(Debug, Clone, BorshDeserialize)]
+pub struct SwapEvent {
+    pub pool_id: [u8; 32],
+    pub trade_direction: bool,
+    pub amount_in: u64,
+    pub amount_out: u64,
+    pub sqrt_price: u128,
+    pub current_tick: i32,
+    pub protocol_fee_amount: u64,
+    pub host_fee: u64,
+    pub padding: u64,
+}
+
+pub fn decode_swap_event_from_log(data: &str) -> Option<SwapEvent> {
+    let bytes = STANDARD.decode(data).ok()?;
+    if bytes.len() < 8 || bytes[..8] != SWAP_EVENT_DISC {
+        return None;
+    }
+    SwapEvent::try_from_slice(&bytes[8..]).ok()
+}

--- a/jetstreamer-dex-trades/src/decoders/meteora_damm_v2/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_damm_v2/idl.rs
@@ -1,5 +1,5 @@
+use base64::{Engine, engine::general_purpose::STANDARD};
 use borsh::BorshDeserialize;
-use base64::{engine::general_purpose::STANDARD, Engine};
 
 pub const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
 

--- a/jetstreamer-dex-trades/src/decoders/meteora_damm_v2/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_damm_v2/mod.rs
@@ -1,0 +1,229 @@
+pub mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::log_parser::LogParser;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+use std::collections::{HashMap, VecDeque};
+use std::sync::RwLock;
+
+const PROGRAM_ID: &str = "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG";
+
+const POOL_INDEX: usize = 0;
+const VAULT_A_INDEX: usize = 3;
+const VAULT_B_INDEX: usize = 4;
+
+struct EventCache {
+    events: VecDeque<idl::SwapEvent>,
+    truncated: bool,
+}
+
+pub struct MeteoraDammV2Decoder {
+    cache: RwLock<HashMap<String, EventCache>>,
+}
+
+impl MeteoraDammV2Decoder {
+    pub fn new() -> Self {
+        Self {
+            cache: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn pop_event(&self, tx_id: &str) -> Option<idl::SwapEvent> {
+        let mut cache = self.cache.write().unwrap();
+        cache.get_mut(tx_id).and_then(|c| c.events.pop_front())
+    }
+
+    fn decode_from_event(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        event: &idl::SwapEvent,
+    ) -> Option<SwapRecord> {
+        let pool = Address::new_from_array(event.pool_id);
+        let accounts = ix.accounts();
+        let vault_a = accounts.get(VAULT_A_INDEX)?;
+        let vault_b = accounts.get(VAULT_B_INDEX)?;
+
+        let info_a = get_token_account_info(tx, &vault_a.to_string())?;
+        let info_b = get_token_account_info(tx, &vault_b.to_string())?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = if ix.is_inner() {
+            PROGRAM_ID.to_string()
+        } else {
+            String::new()
+        };
+        record.pool_address = pool.to_string();
+        record.sqrt_price = event.sqrt_price.to_string();
+        record.is_base_to_quote = Some(event.trade_direction);
+
+        if event.trade_direction {
+            // A → B: selling A, buying B
+            record.token_sold_mint = info_a.mint.clone();
+            record.token_sold_vault = vault_a.to_string();
+            record.token_sold_amount =
+                event.amount_in as f64 / 10f64.powi(info_a.decimals as i32);
+            record.token_sold_decimals = info_a.decimals;
+            record.token_sold_vault_reserve = info_a.post_balance_scaled();
+
+            record.token_bought_mint = info_b.mint.clone();
+            record.token_bought_vault = vault_b.to_string();
+            record.token_bought_amount =
+                event.amount_out as f64 / 10f64.powi(info_b.decimals as i32);
+            record.token_bought_decimals = info_b.decimals;
+            record.token_bought_vault_reserve = info_b.post_balance_scaled();
+        } else {
+            // B → A: selling B, buying A
+            record.token_sold_mint = info_b.mint.clone();
+            record.token_sold_vault = vault_b.to_string();
+            record.token_sold_amount =
+                event.amount_in as f64 / 10f64.powi(info_b.decimals as i32);
+            record.token_sold_decimals = info_b.decimals;
+            record.token_sold_vault_reserve = info_b.post_balance_scaled();
+
+            record.token_bought_mint = info_a.mint.clone();
+            record.token_bought_vault = vault_a.to_string();
+            record.token_bought_amount =
+                event.amount_out as f64 / 10f64.powi(info_a.decimals as i32);
+            record.token_bought_decimals = info_a.decimals;
+            record.token_bought_vault_reserve = info_a.post_balance_scaled();
+        }
+
+        Some(record)
+    }
+
+    fn decode_from_transfers(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let accounts = ix.accounts();
+        let pool = accounts.get(POOL_INDEX)?;
+        let vault_a = accounts.get(VAULT_A_INDEX)?;
+        let vault_b = accounts.get(VAULT_B_INDEX)?;
+
+        let swap = get_swap_amounts(
+            tx,
+            ix.instruction_index() as usize,
+            ix.inner_instruction_index() as usize,
+            &vault_a.to_string(),
+            &vault_b.to_string(),
+            None,
+            false,
+        )?;
+
+        let bought_reserve = get_token_account_info(tx, &swap.bought.vault)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        let sold_reserve = get_token_account_info(tx, &swap.sold.vault)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = if ix.is_inner() {
+            PROGRAM_ID.to_string()
+        } else {
+            String::new()
+        };
+        record.pool_address = pool.to_string();
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_sold_vault_reserve = sold_reserve;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+        record.token_bought_vault_reserve = bought_reserve;
+
+        Some(record)
+    }
+}
+
+impl DexDecoder for MeteoraDammV2Decoder {
+    fn name(&self) -> &'static str {
+        "Meteora DAMM V2"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn on_transaction_start(&self, tx: &TransactionData) {
+        let logs = tx.get_logs();
+        let truncated = LogParser::is_truncated(&logs);
+
+        let data_by_pos = LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
+        let mut sorted: Vec<(String, String)> = Vec::new();
+        for (pos, entries) in &data_by_pos {
+            for entry in entries {
+                sorted.push((pos.clone(), entry.clone()));
+            }
+        }
+        sorted.sort_by(|a, b| parse_position(&a.0).cmp(&parse_position(&b.0)));
+
+        let mut events = VecDeque::new();
+        for (_pos, data) in sorted {
+            if let Some(event) = idl::decode_swap_event_from_log(&data) {
+                events.push_back(event);
+            }
+        }
+
+        let tx_id = tx.signature.to_string();
+        let mut cache = self.cache.write().unwrap();
+        cache.insert(tx_id, EventCache { events, truncated });
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        if !ix.has_discriminator(&idl::SWAP_DISC) {
+            return None;
+        }
+
+        let tx_id = tx.signature.to_string();
+
+        if let Some(event) = self.pop_event(&tx_id) {
+            if let Some(record) = self.decode_from_event(tx, ix, outer_program, &event) {
+                return Some(record);
+            }
+        }
+
+        self.decode_from_transfers(tx, ix, outer_program)
+    }
+
+    fn on_transaction_end(&self, tx_id: &str) {
+        let mut cache = self.cache.write().unwrap();
+        cache.remove(tx_id);
+    }
+}
+
+fn parse_position(pos: &str) -> (usize, usize) {
+    let mut parts = pos.split('.');
+    let outer = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let inner = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (outer, inner)
+}

--- a/jetstreamer-dex-trades/src/decoders/meteora_damm_v2/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_damm_v2/mod.rs
@@ -19,11 +19,17 @@ const VAULT_B_INDEX: usize = 4;
 
 struct EventCache {
     events: VecDeque<idl::SwapEvent>,
-    truncated: bool,
+    _truncated: bool,
 }
 
 pub struct MeteoraDammV2Decoder {
     cache: RwLock<HashMap<String, EventCache>>,
+}
+
+impl Default for MeteoraDammV2Decoder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MeteoraDammV2Decoder {
@@ -72,8 +78,7 @@ impl MeteoraDammV2Decoder {
             // A → B: selling A, buying B
             record.token_sold_mint = info_a.mint.clone();
             record.token_sold_vault = vault_a.to_string();
-            record.token_sold_amount =
-                event.amount_in as f64 / 10f64.powi(info_a.decimals as i32);
+            record.token_sold_amount = event.amount_in as f64 / 10f64.powi(info_a.decimals as i32);
             record.token_sold_decimals = info_a.decimals;
             record.token_sold_vault_reserve = info_a.post_balance_scaled();
 
@@ -87,8 +92,7 @@ impl MeteoraDammV2Decoder {
             // B → A: selling B, buying A
             record.token_sold_mint = info_b.mint.clone();
             record.token_sold_vault = vault_b.to_string();
-            record.token_sold_amount =
-                event.amount_in as f64 / 10f64.powi(info_b.decimals as i32);
+            record.token_sold_amount = event.amount_in as f64 / 10f64.powi(info_b.decimals as i32);
             record.token_sold_decimals = info_b.decimals;
             record.token_sold_vault_reserve = info_b.post_balance_scaled();
 
@@ -191,7 +195,13 @@ impl DexDecoder for MeteoraDammV2Decoder {
 
         let tx_id = tx.signature.to_string();
         let mut cache = self.cache.write().unwrap();
-        cache.insert(tx_id, EventCache { events, truncated });
+        cache.insert(
+            tx_id,
+            EventCache {
+                events,
+                _truncated: truncated,
+            },
+        );
     }
 
     fn decode_instruction(
@@ -206,10 +216,10 @@ impl DexDecoder for MeteoraDammV2Decoder {
 
         let tx_id = tx.signature.to_string();
 
-        if let Some(event) = self.pop_event(&tx_id) {
-            if let Some(record) = self.decode_from_event(tx, ix, outer_program, &event) {
-                return Some(record);
-            }
+        if let Some(event) = self.pop_event(&tx_id)
+            && let Some(record) = self.decode_from_event(tx, ix, outer_program, &event)
+        {
+            return Some(record);
         }
 
         self.decode_from_transfers(tx, ix, outer_program)

--- a/jetstreamer-dex-trades/src/decoders/meteora_dbc/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_dbc/idl.rs
@@ -18,6 +18,7 @@ pub const SELL_EVENT_DISC: [u8; 8] = [62, 47, 55, 210, 224, 105, 121, 62];
 
 /// Swap event emitted by Meteora DBC via Anchor self-CPI.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct SwapEvent {
     pub pool: [u8; 32],
     pub token_a_amount: u64,

--- a/jetstreamer-dex-trades/src/decoders/meteora_dbc/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_dbc/idl.rs
@@ -1,0 +1,89 @@
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::Cursor;
+
+const PUBKEY_LEN: usize = 32;
+
+/// Anchor self-CPI event wrapper discriminator (sha256("anchor:event")[..8]).
+pub const EVENT_WRAPPER_DISC: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+
+/// Buy instruction discriminator.
+pub const BUY_DISC: [u8; 8] = [102, 6, 61, 18, 1, 218, 235, 234];
+/// Sell instruction discriminator.
+pub const SELL_DISC: [u8; 8] = [51, 230, 133, 164, 1, 127, 131, 173];
+
+/// Buy event discriminator (inner, after event wrapper).
+pub const BUY_EVENT_DISC: [u8; 8] = [103, 244, 82, 31, 44, 245, 119, 119];
+/// Sell event discriminator (inner, after event wrapper).
+pub const SELL_EVENT_DISC: [u8; 8] = [62, 47, 55, 210, 224, 105, 121, 62];
+
+/// Swap event emitted by Meteora DBC via Anchor self-CPI.
+#[derive(Debug, Clone)]
+pub struct SwapEvent {
+    pub pool: [u8; 32],
+    pub token_a_amount: u64,
+    pub token_b_amount: u64,
+    pub a_to_b: bool,
+    pub token_a_mint: [u8; 32],
+    pub token_b_mint: [u8; 32],
+}
+
+impl SwapEvent {
+    /// Layout: pool(32) + token_a_amount(8) + token_b_amount(8) + a_to_b(1) +
+    ///         token_a_mint(32) + token_b_mint(32) = 113 bytes
+    pub fn deserialize(data: &[u8]) -> Option<Self> {
+        if data.len() < 113 {
+            return None;
+        }
+
+        let mut cursor = Cursor::new(data);
+
+        let mut pool = [0u8; PUBKEY_LEN];
+        std::io::Read::read_exact(&mut cursor, &mut pool).ok()?;
+
+        let token_a_amount = cursor.read_u64::<LittleEndian>().ok()?;
+        let token_b_amount = cursor.read_u64::<LittleEndian>().ok()?;
+        let a_to_b = cursor.read_u8().ok()? != 0;
+
+        let mut token_a_mint = [0u8; PUBKEY_LEN];
+        std::io::Read::read_exact(&mut cursor, &mut token_a_mint).ok()?;
+
+        let mut token_b_mint = [0u8; PUBKEY_LEN];
+        std::io::Read::read_exact(&mut cursor, &mut token_b_mint).ok()?;
+
+        Some(Self {
+            pool,
+            token_a_amount,
+            token_b_amount,
+            a_to_b,
+            token_a_mint,
+            token_b_mint,
+        })
+    }
+}
+
+pub mod events {
+    use super::*;
+
+    /// Decode a swap event from Anchor self-CPI instruction data.
+    /// Data layout: event_wrapper_disc(8) + inner_event_disc(8) + payload.
+    pub fn decode_swap_event(data: &[u8]) -> Option<(SwapEvent, bool)> {
+        if data.len() < 16 {
+            return None;
+        }
+        if data[..8] != EVENT_WRAPPER_DISC {
+            return None;
+        }
+
+        let inner_disc = &data[8..16];
+        let is_buy = if inner_disc == BUY_EVENT_DISC {
+            true
+        } else if inner_disc == SELL_EVENT_DISC {
+            false
+        } else {
+            return None;
+        };
+
+        let event = SwapEvent::deserialize(&data[16..])?;
+        Some((event, is_buy))
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/meteora_dbc/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_dbc/mod.rs
@@ -1,0 +1,220 @@
+mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::log_parser::LogParser;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+
+const PROGRAM_ID: &str = "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN";
+
+pub struct MeteoraDbcDecoder;
+
+impl MeteoraDbcDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for MeteoraDbcDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for MeteoraDbcDecoder {
+    fn name(&self) -> &'static str {
+        "Meteora DBC"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+
+        if let Some((event, is_buy)) = idl::events::decode_swap_event(data) {
+            return self.decode_from_event(tx, ix, outer_program, &accounts, &event, is_buy);
+        }
+
+        let is_buy = data.len() >= 8 && data[..8] == idl::BUY_DISC;
+        let is_sell = data.len() >= 8 && data[..8] == idl::SELL_DISC;
+        if !is_buy && !is_sell {
+            return None;
+        }
+
+        let logs = tx.get_logs();
+        if !LogParser::is_truncated(&logs) {
+            let position = format!(
+                "{}.{}",
+                ix.instruction_index(),
+                ix.inner_instruction_index()
+            );
+            let data_events =
+                LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
+            if let Some(events) = data_events.get(&position) {
+                for event_data in events {
+                    if let Ok(decoded) = base64::Engine::decode(
+                        &base64::engine::general_purpose::STANDARD,
+                        event_data,
+                    ) {
+                        if let Some((event, _)) = idl::events::decode_swap_event(&decoded) {
+                            return self.decode_from_event(
+                                tx,
+                                ix,
+                                outer_program,
+                                &accounts,
+                                &event,
+                                is_buy,
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        self.decode_from_transfers(tx, ix, outer_program, &accounts, is_buy)
+    }
+}
+
+impl MeteoraDbcDecoder {
+    fn decode_from_event(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        accounts: &[String],
+        event: &idl::SwapEvent,
+        is_buy: bool,
+    ) -> Option<SwapRecord> {
+        let pool = Address::new_from_array(event.pool).to_string();
+        let token_a_mint = Address::new_from_array(event.token_a_mint).to_string();
+        let token_b_mint = Address::new_from_array(event.token_b_mint).to_string();
+
+        let base_vault = accounts.get(4).cloned().unwrap_or_default();
+        let quote_vault = accounts.get(5).cloned().unwrap_or_default();
+
+        let base_info = get_token_account_info(tx, &base_vault);
+        let quote_info = get_token_account_info(tx, &quote_vault);
+
+        let base_decimals = base_info.as_ref().map(|i| i.decimals).unwrap_or(6);
+        let quote_decimals = quote_info.as_ref().map(|i| i.decimals).unwrap_or(6);
+
+        let token_a_amount =
+            event.token_a_amount as f64 / 10f64.powi(base_decimals as i32);
+        let token_b_amount =
+            event.token_b_amount as f64 / 10f64.powi(quote_decimals as i32);
+
+        let base_reserve = base_info
+            .as_ref()
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        let quote_reserve = quote_info
+            .as_ref()
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        if is_buy {
+            record.instruction_type = "Buy".to_string();
+            record.token_bought_mint = token_a_mint;
+            record.token_bought_vault = base_vault;
+            record.token_bought_amount = token_a_amount;
+            record.token_bought_decimals = base_decimals;
+            record.token_bought_vault_reserve = base_reserve;
+            record.token_sold_mint = token_b_mint;
+            record.token_sold_vault = quote_vault;
+            record.token_sold_amount = token_b_amount;
+            record.token_sold_decimals = quote_decimals;
+            record.token_sold_vault_reserve = quote_reserve;
+        } else {
+            record.instruction_type = "Sell".to_string();
+            record.token_bought_mint = token_b_mint;
+            record.token_bought_vault = quote_vault;
+            record.token_bought_amount = token_b_amount;
+            record.token_bought_decimals = quote_decimals;
+            record.token_bought_vault_reserve = quote_reserve;
+            record.token_sold_mint = token_a_mint;
+            record.token_sold_vault = base_vault;
+            record.token_sold_amount = token_a_amount;
+            record.token_sold_decimals = base_decimals;
+            record.token_sold_vault_reserve = base_reserve;
+        }
+
+        Some(record)
+    }
+
+    fn decode_from_transfers(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        accounts: &[String],
+        is_buy: bool,
+    ) -> Option<SwapRecord> {
+        let pool_address = accounts.first().cloned().unwrap_or_default();
+        let base_vault = accounts.get(4).cloned().unwrap_or_default();
+        let quote_vault = accounts.get(5).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+        let swap = get_swap_amounts(
+            tx, outer_idx, inner_idx, &base_vault, &quote_vault, None, false,
+        )?;
+
+        let base_reserve = get_token_account_info(tx, &base_vault)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        let quote_reserve = get_token_account_info(tx, &quote_vault)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = if is_buy { "Buy" } else { "Sell" }.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool_address;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+        record.token_bought_vault_reserve = if swap.bought.vault == base_vault {
+            base_reserve
+        } else {
+            quote_reserve
+        };
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_sold_vault_reserve = if swap.sold.vault == base_vault {
+            base_reserve
+        } else {
+            quote_reserve
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/meteora_dbc/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_dbc/mod.rs
@@ -60,24 +60,22 @@ impl DexDecoder for MeteoraDbcDecoder {
                 ix.instruction_index(),
                 ix.inner_instruction_index()
             );
-            let data_events =
-                LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
+            let data_events = LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
             if let Some(events) = data_events.get(&position) {
                 for event_data in events {
                     if let Ok(decoded) = base64::Engine::decode(
                         &base64::engine::general_purpose::STANDARD,
                         event_data,
-                    ) {
-                        if let Some((event, _)) = idl::events::decode_swap_event(&decoded) {
-                            return self.decode_from_event(
-                                tx,
-                                ix,
-                                outer_program,
-                                &accounts,
-                                &event,
-                                is_buy,
-                            );
-                        }
+                    ) && let Some((event, _)) = idl::events::decode_swap_event(&decoded)
+                    {
+                        return self.decode_from_event(
+                            tx,
+                            ix,
+                            outer_program,
+                            &accounts,
+                            &event,
+                            is_buy,
+                        );
                     }
                 }
             }
@@ -110,10 +108,8 @@ impl MeteoraDbcDecoder {
         let base_decimals = base_info.as_ref().map(|i| i.decimals).unwrap_or(6);
         let quote_decimals = quote_info.as_ref().map(|i| i.decimals).unwrap_or(6);
 
-        let token_a_amount =
-            event.token_a_amount as f64 / 10f64.powi(base_decimals as i32);
-        let token_b_amount =
-            event.token_b_amount as f64 / 10f64.powi(quote_decimals as i32);
+        let token_a_amount = event.token_a_amount as f64 / 10f64.powi(base_decimals as i32);
+        let token_b_amount = event.token_b_amount as f64 / 10f64.powi(quote_decimals as i32);
 
         let base_reserve = base_info
             .as_ref()
@@ -176,7 +172,13 @@ impl MeteoraDbcDecoder {
         let outer_idx = ix.instruction_index() as usize;
         let inner_idx = ix.inner_instruction_index() as usize;
         let swap = get_swap_amounts(
-            tx, outer_idx, inner_idx, &base_vault, &quote_vault, None, false,
+            tx,
+            outer_idx,
+            inner_idx,
+            &base_vault,
+            &quote_vault,
+            None,
+            false,
         )?;
 
         let base_reserve = get_token_account_info(tx, &base_vault)

--- a/jetstreamer-dex-trades/src/decoders/meteora_dlmm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_dlmm/idl.rs
@@ -1,0 +1,28 @@
+use borsh::BorshDeserialize;
+use base64::{engine::general_purpose::STANDARD, Engine};
+
+pub const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub const SWAP_EVENT_DISC: [u8; 8] = [231, 195, 65, 79, 107, 30, 205, 218];
+
+#[derive(Debug, Clone, BorshDeserialize)]
+pub struct SwapEvent {
+    pub lb_pair: [u8; 32],
+    pub from: [u8; 32],
+    pub start_bin_id: i32,
+    pub end_bin_id: i32,
+    pub amount_in: u64,
+    pub amount_out: u64,
+    pub swap_for_y: bool,
+    pub fee: u64,
+    pub protocol_fee: u64,
+    pub host_fee: u64,
+}
+
+pub fn decode_swap_event_from_log(data: &str) -> Option<SwapEvent> {
+    let bytes = STANDARD.decode(data).ok()?;
+    if bytes.len() < 8 || bytes[..8] != SWAP_EVENT_DISC {
+        return None;
+    }
+    SwapEvent::try_from_slice(&bytes[8..]).ok()
+}

--- a/jetstreamer-dex-trades/src/decoders/meteora_dlmm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_dlmm/idl.rs
@@ -1,5 +1,5 @@
+use base64::{Engine, engine::general_purpose::STANDARD};
 use borsh::BorshDeserialize;
-use base64::{engine::general_purpose::STANDARD, Engine};
 
 pub const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
 

--- a/jetstreamer-dex-trades/src/decoders/meteora_dlmm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_dlmm/mod.rs
@@ -19,11 +19,17 @@ const VAULT_Y_INDEX: usize = 4;
 
 struct EventCache {
     events: VecDeque<idl::SwapEvent>,
-    truncated: bool,
+    _truncated: bool,
 }
 
 pub struct MeteoraDlmmDecoder {
     cache: RwLock<HashMap<String, EventCache>>,
+}
+
+impl Default for MeteoraDlmmDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl MeteoraDlmmDecoder {
@@ -70,8 +76,7 @@ impl MeteoraDlmmDecoder {
             // Selling X, buying Y
             record.token_sold_mint = info_x.mint.clone();
             record.token_sold_vault = vault_x.to_string();
-            record.token_sold_amount =
-                event.amount_in as f64 / 10f64.powi(info_x.decimals as i32);
+            record.token_sold_amount = event.amount_in as f64 / 10f64.powi(info_x.decimals as i32);
             record.token_sold_decimals = info_x.decimals;
             record.token_sold_vault_reserve = info_x.post_balance_scaled();
 
@@ -85,8 +90,7 @@ impl MeteoraDlmmDecoder {
             // Selling Y, buying X
             record.token_sold_mint = info_y.mint.clone();
             record.token_sold_vault = vault_y.to_string();
-            record.token_sold_amount =
-                event.amount_in as f64 / 10f64.powi(info_y.decimals as i32);
+            record.token_sold_amount = event.amount_in as f64 / 10f64.powi(info_y.decimals as i32);
             record.token_sold_decimals = info_y.decimals;
             record.token_sold_vault_reserve = info_y.post_balance_scaled();
 
@@ -189,7 +193,13 @@ impl DexDecoder for MeteoraDlmmDecoder {
 
         let tx_id = tx.signature.to_string();
         let mut cache = self.cache.write().unwrap();
-        cache.insert(tx_id, EventCache { events, truncated });
+        cache.insert(
+            tx_id,
+            EventCache {
+                events,
+                _truncated: truncated,
+            },
+        );
     }
 
     fn decode_instruction(
@@ -204,10 +214,10 @@ impl DexDecoder for MeteoraDlmmDecoder {
 
         let tx_id = tx.signature.to_string();
 
-        if let Some(event) = self.pop_event(&tx_id) {
-            if let Some(record) = self.decode_from_event(tx, ix, outer_program, &event) {
-                return Some(record);
-            }
+        if let Some(event) = self.pop_event(&tx_id)
+            && let Some(record) = self.decode_from_event(tx, ix, outer_program, &event)
+        {
+            return Some(record);
         }
 
         self.decode_from_transfers(tx, ix, outer_program)

--- a/jetstreamer-dex-trades/src/decoders/meteora_dlmm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_dlmm/mod.rs
@@ -1,0 +1,227 @@
+pub mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::log_parser::LogParser;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+use std::collections::{HashMap, VecDeque};
+use std::sync::RwLock;
+
+const PROGRAM_ID: &str = "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo";
+
+const POOL_INDEX: usize = 0;
+const VAULT_X_INDEX: usize = 3;
+const VAULT_Y_INDEX: usize = 4;
+
+struct EventCache {
+    events: VecDeque<idl::SwapEvent>,
+    truncated: bool,
+}
+
+pub struct MeteoraDlmmDecoder {
+    cache: RwLock<HashMap<String, EventCache>>,
+}
+
+impl MeteoraDlmmDecoder {
+    pub fn new() -> Self {
+        Self {
+            cache: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn pop_event(&self, tx_id: &str) -> Option<idl::SwapEvent> {
+        let mut cache = self.cache.write().unwrap();
+        cache.get_mut(tx_id).and_then(|c| c.events.pop_front())
+    }
+
+    fn decode_from_event(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        event: &idl::SwapEvent,
+    ) -> Option<SwapRecord> {
+        let pool = Address::new_from_array(event.lb_pair);
+        let accounts = ix.accounts();
+        let vault_x = accounts.get(VAULT_X_INDEX)?;
+        let vault_y = accounts.get(VAULT_Y_INDEX)?;
+
+        let info_x = get_token_account_info(tx, &vault_x.to_string())?;
+        let info_y = get_token_account_info(tx, &vault_y.to_string())?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = if ix.is_inner() {
+            PROGRAM_ID.to_string()
+        } else {
+            String::new()
+        };
+        record.pool_address = pool.to_string();
+
+        if event.swap_for_y {
+            // Selling X, buying Y
+            record.token_sold_mint = info_x.mint.clone();
+            record.token_sold_vault = vault_x.to_string();
+            record.token_sold_amount =
+                event.amount_in as f64 / 10f64.powi(info_x.decimals as i32);
+            record.token_sold_decimals = info_x.decimals;
+            record.token_sold_vault_reserve = info_x.post_balance_scaled();
+
+            record.token_bought_mint = info_y.mint.clone();
+            record.token_bought_vault = vault_y.to_string();
+            record.token_bought_amount =
+                event.amount_out as f64 / 10f64.powi(info_y.decimals as i32);
+            record.token_bought_decimals = info_y.decimals;
+            record.token_bought_vault_reserve = info_y.post_balance_scaled();
+        } else {
+            // Selling Y, buying X
+            record.token_sold_mint = info_y.mint.clone();
+            record.token_sold_vault = vault_y.to_string();
+            record.token_sold_amount =
+                event.amount_in as f64 / 10f64.powi(info_y.decimals as i32);
+            record.token_sold_decimals = info_y.decimals;
+            record.token_sold_vault_reserve = info_y.post_balance_scaled();
+
+            record.token_bought_mint = info_x.mint.clone();
+            record.token_bought_vault = vault_x.to_string();
+            record.token_bought_amount =
+                event.amount_out as f64 / 10f64.powi(info_x.decimals as i32);
+            record.token_bought_decimals = info_x.decimals;
+            record.token_bought_vault_reserve = info_x.post_balance_scaled();
+        }
+
+        Some(record)
+    }
+
+    fn decode_from_transfers(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let accounts = ix.accounts();
+        let pool = accounts.get(POOL_INDEX)?;
+        let vault_x = accounts.get(VAULT_X_INDEX)?;
+        let vault_y = accounts.get(VAULT_Y_INDEX)?;
+
+        let swap = get_swap_amounts(
+            tx,
+            ix.instruction_index() as usize,
+            ix.inner_instruction_index() as usize,
+            &vault_x.to_string(),
+            &vault_y.to_string(),
+            None,
+            false,
+        )?;
+
+        let bought_reserve = get_token_account_info(tx, &swap.bought.vault)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        let sold_reserve = get_token_account_info(tx, &swap.sold.vault)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = if ix.is_inner() {
+            PROGRAM_ID.to_string()
+        } else {
+            String::new()
+        };
+        record.pool_address = pool.to_string();
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_sold_vault_reserve = sold_reserve;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+        record.token_bought_vault_reserve = bought_reserve;
+
+        Some(record)
+    }
+}
+
+impl DexDecoder for MeteoraDlmmDecoder {
+    fn name(&self) -> &'static str {
+        "Meteora DLMM"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn on_transaction_start(&self, tx: &TransactionData) {
+        let logs = tx.get_logs();
+        let truncated = LogParser::is_truncated(&logs);
+
+        let data_by_pos = LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
+        let mut sorted: Vec<(String, String)> = Vec::new();
+        for (pos, entries) in &data_by_pos {
+            for entry in entries {
+                sorted.push((pos.clone(), entry.clone()));
+            }
+        }
+        sorted.sort_by(|a, b| parse_position(&a.0).cmp(&parse_position(&b.0)));
+
+        let mut events = VecDeque::new();
+        for (_pos, data) in sorted {
+            if let Some(event) = idl::decode_swap_event_from_log(&data) {
+                events.push_back(event);
+            }
+        }
+
+        let tx_id = tx.signature.to_string();
+        let mut cache = self.cache.write().unwrap();
+        cache.insert(tx_id, EventCache { events, truncated });
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        if !ix.has_discriminator(&idl::SWAP_DISC) {
+            return None;
+        }
+
+        let tx_id = tx.signature.to_string();
+
+        if let Some(event) = self.pop_event(&tx_id) {
+            if let Some(record) = self.decode_from_event(tx, ix, outer_program, &event) {
+                return Some(record);
+            }
+        }
+
+        self.decode_from_transfers(tx, ix, outer_program)
+    }
+
+    fn on_transaction_end(&self, tx_id: &str) {
+        let mut cache = self.cache.write().unwrap();
+        cache.remove(tx_id);
+    }
+}
+
+fn parse_position(pos: &str) -> (usize, usize) {
+    let mut parts = pos.split('.');
+    let outer = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let inner = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (outer, inner)
+}

--- a/jetstreamer-dex-trades/src/decoders/meteora_pools/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_pools/idl.rs
@@ -12,6 +12,7 @@ pub const EVENT_WRAPPER_DISC: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
 
 /// Meteora Pools swap event — contains amounts and fees but NO direction info.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct SwapEvent {
     pub in_amount: u64,
     pub out_amount: u64,

--- a/jetstreamer-dex-trades/src/decoders/meteora_pools/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_pools/idl.rs
@@ -1,0 +1,68 @@
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::Cursor;
+
+/// Swap instruction discriminator.
+pub const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+/// Swap event discriminator (Anchor self-CPI event inner disc).
+pub const SWAP_EVENT_DISC: [u8; 8] = [81, 108, 227, 190, 205, 208, 10, 196];
+
+/// Anchor self-CPI event wrapper discriminator.
+pub const EVENT_WRAPPER_DISC: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+
+/// Meteora Pools swap event — contains amounts and fees but NO direction info.
+#[derive(Debug, Clone)]
+pub struct SwapEvent {
+    pub in_amount: u64,
+    pub out_amount: u64,
+    pub trade_fee: u64,
+    pub protocol_fee: u64,
+    pub host_fee: u64,
+}
+
+impl SwapEvent {
+    /// Layout: in_amount(8) + out_amount(8) + trade_fee(8) + protocol_fee(8) + host_fee(8) = 40 bytes
+    pub fn deserialize(data: &[u8]) -> Option<Self> {
+        if data.len() < 40 {
+            return None;
+        }
+
+        let mut cursor = Cursor::new(data);
+
+        let in_amount = cursor.read_u64::<LittleEndian>().ok()?;
+        let out_amount = cursor.read_u64::<LittleEndian>().ok()?;
+        let trade_fee = cursor.read_u64::<LittleEndian>().ok()?;
+        let protocol_fee = cursor.read_u64::<LittleEndian>().ok()?;
+        let host_fee = cursor.read_u64::<LittleEndian>().ok()?;
+
+        Some(Self {
+            in_amount,
+            out_amount,
+            trade_fee,
+            protocol_fee,
+            host_fee,
+        })
+    }
+}
+
+pub mod events {
+    use super::*;
+
+    /// Decode a swap event from Anchor self-CPI instruction data.
+    /// Data layout: event_wrapper_disc(8) + swap_event_disc(8) + payload.
+    pub fn decode_swap_event(data: &[u8]) -> Option<SwapEvent> {
+        if data.len() < 16 {
+            return None;
+        }
+        if data[..8] != EVENT_WRAPPER_DISC {
+            return None;
+        }
+
+        let inner_disc = &data[8..16];
+        if inner_disc != SWAP_EVENT_DISC {
+            return None;
+        }
+
+        SwapEvent::deserialize(&data[16..])
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/meteora_pools/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_pools/mod.rs
@@ -1,0 +1,118 @@
+mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::log_parser::LogParser;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB";
+
+pub struct MeteoraPoolsDecoder;
+
+impl MeteoraPoolsDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for MeteoraPoolsDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for MeteoraPoolsDecoder {
+    fn name(&self) -> &'static str {
+        "Meteora Pools"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 || data[..8] != idl::SWAP_DISC {
+            return None;
+        }
+
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+        let pool_address = accounts.first().cloned().unwrap_or_default();
+        let vault_a = accounts.get(4).cloned().unwrap_or_default();
+        let vault_b = accounts.get(5).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let logs = tx.get_logs();
+        let truncated = LogParser::is_truncated(&logs);
+
+        if !truncated {
+            let position = format!("{}.{}", ix.instruction_index(), ix.inner_instruction_index());
+            let data_events = LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
+            if let Some(events) = data_events.get(&position) {
+                for event_data in events {
+                    if let Ok(decoded) = base64::Engine::decode(
+                        &base64::engine::general_purpose::STANDARD,
+                        event_data,
+                    ) {
+                        if let Some(_event) = idl::events::decode_swap_event(&decoded) {
+                            // Event has no direction info — must still use transfers
+                            // to determine which token was bought vs sold.
+                        }
+                    }
+                }
+            }
+        }
+
+        let swap = get_swap_amounts(
+            tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false,
+        )?;
+
+        let vault_a_reserve = get_token_account_info(tx, &vault_a)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        let vault_b_reserve = get_token_account_info(tx, &vault_b)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "Swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool_address;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+        record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
+            vault_a_reserve
+        } else {
+            vault_b_reserve
+        };
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
+            vault_a_reserve
+        } else {
+            vault_b_reserve
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/meteora_pools/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/meteora_pools/mod.rs
@@ -56,26 +56,27 @@ impl DexDecoder for MeteoraPoolsDecoder {
         let truncated = LogParser::is_truncated(&logs);
 
         if !truncated {
-            let position = format!("{}.{}", ix.instruction_index(), ix.inner_instruction_index());
+            let position = format!(
+                "{}.{}",
+                ix.instruction_index(),
+                ix.inner_instruction_index()
+            );
             let data_events = LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
             if let Some(events) = data_events.get(&position) {
                 for event_data in events {
                     if let Ok(decoded) = base64::Engine::decode(
                         &base64::engine::general_purpose::STANDARD,
                         event_data,
-                    ) {
-                        if let Some(_event) = idl::events::decode_swap_event(&decoded) {
-                            // Event has no direction info — must still use transfers
-                            // to determine which token was bought vs sold.
-                        }
+                    ) && let Some(_event) = idl::events::decode_swap_event(&decoded)
+                    {
+                        // Event has no direction info — must still use transfers
+                        // to determine which token was bought vs sold.
                     }
                 }
             }
         }
 
-        let swap = get_swap_amounts(
-            tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false,
-        )?;
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
 
         let vault_a_reserve = get_token_account_info(tx, &vault_a)
             .map(|i| i.post_balance_scaled())

--- a/jetstreamer-dex-trades/src/decoders/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/mod.rs
@@ -1,0 +1,68 @@
+//! Individual DEX decoder implementations.
+
+pub mod alphaq;
+pub mod aquifer;
+pub mod bisonfi;
+pub mod byreal_clmm;
+pub mod futarchy_amm;
+pub mod goonfi;
+pub mod humidifi;
+pub mod lifinity_v1;
+pub mod lifinity_v2;
+pub mod manifest;
+pub mod meteora_damm_v2;
+pub mod meteora_dbc;
+pub mod meteora_dlmm;
+pub mod meteora_pools;
+pub mod obric_v2;
+pub mod orca_v2;
+pub mod orca_whirlpool;
+pub mod pancakeswap_clmm;
+pub mod pump_amm;
+pub mod pump_fun;
+pub mod raydium_amm_v4;
+pub mod raydium_clmm;
+pub mod raydium_cpmm;
+pub mod raydium_launchlab;
+pub mod solfi_v1;
+pub mod solfi_v2;
+pub mod stabble_stable;
+pub mod stabble_weighted;
+pub mod tessera;
+pub mod zerofi;
+
+use crate::registry::DexRegistry;
+
+/// Register all built-in DEX decoders with the given registry.
+pub fn register_all(registry: &mut DexRegistry) {
+    registry.register(Box::new(pump_fun::PumpFunDecoder));
+    registry.register(Box::new(pump_amm::PumpAmmDecoder));
+    registry.register(Box::new(raydium_amm_v4::RaydiumAmmV4Decoder::new()));
+    registry.register(Box::new(raydium_cpmm::RaydiumCpmmDecoder::new()));
+    registry.register(Box::new(raydium_clmm::RaydiumClmmDecoder::new()));
+    registry.register(Box::new(raydium_launchlab::RaydiumLaunchLabDecoder::new()));
+    registry.register(Box::new(orca_whirlpool::OrcaWhirlpoolDecoder::new()));
+    registry.register(Box::new(orca_v2::OrcaV2Decoder));
+    registry.register(Box::new(meteora_damm_v2::MeteoraDammV2Decoder::new()));
+    registry.register(Box::new(meteora_dbc::MeteoraDbcDecoder::new()));
+    registry.register(Box::new(meteora_dlmm::MeteoraDlmmDecoder::new()));
+    registry.register(Box::new(meteora_pools::MeteoraPoolsDecoder::new()));
+    registry.register(Box::new(manifest::ManifestDecoder));
+    registry.register(Box::new(aquifer::AquiferDecoder));
+    registry.register(Box::new(alphaq::AlphaQDecoder));
+    registry.register(Box::new(bisonfi::BisonFiDecoder));
+    registry.register(Box::new(zerofi::ZerofiDecoder));
+    registry.register(Box::new(goonfi::GoonfiDecoder));
+    registry.register(Box::new(humidifi::HumidifiDecoder));
+    registry.register(Box::new(tessera::TesseraDecoder));
+    registry.register(Box::new(obric_v2::ObricV2Decoder));
+    registry.register(Box::new(solfi_v1::SolfiV1Decoder));
+    registry.register(Box::new(solfi_v2::SolfiV2Decoder));
+    registry.register(Box::new(stabble_stable::StabbleStableDecoder));
+    registry.register(Box::new(stabble_weighted::StabbleWeightedDecoder));
+    registry.register(Box::new(lifinity_v1::LifinityV1Decoder));
+    registry.register(Box::new(lifinity_v2::LifinityV2Decoder));
+    registry.register(Box::new(futarchy_amm::FutarchyAmmDecoder::new()));
+    registry.register(Box::new(pancakeswap_clmm::PancakeSwapClmmDecoder));
+    registry.register(Box::new(byreal_clmm::ByrealClmmDecoder));
+}

--- a/jetstreamer-dex-trades/src/decoders/obric_v2/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/obric_v2/mod.rs
@@ -1,7 +1,7 @@
 use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
 use crate::token_transfers::{get_swap_amounts_partial, get_token_account_info};
 use crate::types::SwapRecord;
-use crate::registry::DexDecoder;
 use jetstreamer_firehose::firehose::TransactionData;
 
 const PROGRAM_ID: &str = "obriQD1zbpyLz95G5n7nJe6a4DPjpFwa5XYPoNm113y";
@@ -61,23 +61,23 @@ impl DexDecoder for ObricV2Decoder {
             &quote_info,
         )?;
 
-        let sold = partial.sold.unwrap_or_else(|| {
-            crate::token_transfers::TransferInfo {
+        let sold = partial
+            .sold
+            .unwrap_or_else(|| crate::token_transfers::TransferInfo {
                 mint: base_info.mint.clone(),
                 vault: base_vault.clone(),
                 amount: 0,
                 decimals: base_info.decimals,
-            }
-        });
+            });
 
-        let bought = partial.bought.unwrap_or_else(|| {
-            crate::token_transfers::TransferInfo {
+        let bought = partial
+            .bought
+            .unwrap_or_else(|| crate::token_transfers::TransferInfo {
                 mint: quote_info.mint.clone(),
                 vault: quote_vault.clone(),
                 amount: 0,
                 decimals: quote_info.decimals,
-            }
-        });
+            });
 
         let _ = data;
 
@@ -102,10 +102,12 @@ impl DexDecoder for ObricV2Decoder {
 
         let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
         let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
-        record.token_sold_vault_reserve =
-            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
-        record.token_bought_vault_reserve =
-            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_sold_vault_reserve = sold_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        record.token_bought_vault_reserve = bought_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
 
         Some(record)
     }

--- a/jetstreamer-dex-trades/src/decoders/obric_v2/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/obric_v2/mod.rs
@@ -1,0 +1,112 @@
+use crate::instruction_iter::Instruction;
+use crate::token_transfers::{get_swap_amounts_partial, get_token_account_info};
+use crate::types::SwapRecord;
+use crate::registry::DexDecoder;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "obriQD1zbpyLz95G5n7nJe6a4DPjpFwa5XYPoNm113y";
+
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+const SWAP2_DISC: [u8; 8] = [65, 75, 63, 76, 235, 91, 91, 136];
+
+pub struct ObricV2Decoder;
+
+impl DexDecoder for ObricV2Decoder {
+    fn name(&self) -> &'static str {
+        "Obric V2"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        let accounts = ix.accounts();
+
+        let instruction_type = if ix.has_discriminator(&SWAP_DISC) {
+            "Swap"
+        } else if ix.has_discriminator(&SWAP2_DISC) {
+            "Swap2"
+        } else {
+            return None;
+        };
+
+        if accounts.len() < 5 {
+            return None;
+        }
+
+        let pool = accounts[0].to_string();
+        let base_vault = accounts[3].to_string();
+        let quote_vault = accounts[4].to_string();
+
+        let base_info = get_token_account_info(tx, &base_vault)?;
+        let quote_info = get_token_account_info(tx, &quote_vault)?;
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let partial = get_swap_amounts_partial(
+            tx,
+            outer_idx,
+            inner_idx,
+            &base_vault,
+            &quote_vault,
+            &base_info,
+            &quote_info,
+        )?;
+
+        let sold = partial.sold.unwrap_or_else(|| {
+            crate::token_transfers::TransferInfo {
+                mint: base_info.mint.clone(),
+                vault: base_vault.clone(),
+                amount: 0,
+                decimals: base_info.decimals,
+            }
+        });
+
+        let bought = partial.bought.unwrap_or_else(|| {
+            crate::token_transfers::TransferInfo {
+                mint: quote_info.mint.clone(),
+                vault: quote_vault.clone(),
+                amount: 0,
+                decimals: quote_info.decimals,
+            }
+        });
+
+        let _ = data;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        record.token_sold_mint = sold.mint.clone();
+        record.token_sold_vault = sold.vault.clone();
+        record.token_sold_amount = sold.amount_scaled();
+        record.token_sold_decimals = sold.decimals;
+
+        record.token_bought_mint = bought.mint.clone();
+        record.token_bought_vault = bought.vault.clone();
+        record.token_bought_amount = bought.amount_scaled();
+        record.token_bought_decimals = bought.decimals;
+
+        let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
+        let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
+        record.token_sold_vault_reserve =
+            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_bought_vault_reserve =
+            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/orca_v2/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/orca_v2/mod.rs
@@ -1,0 +1,70 @@
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP";
+const SWAP_DISC: u8 = 1;
+
+pub struct OrcaV2Decoder;
+
+impl DexDecoder for OrcaV2Decoder {
+    fn name(&self) -> &'static str {
+        "Orca V2"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.is_empty() || data[0] != SWAP_DISC {
+            return None;
+        }
+
+        let accounts = ix.accounts();
+        let pool = accounts.get(0)?.to_string();
+        let vault_a = accounts.get(4)?.to_string();
+        let vault_b = accounts.get(5)?.to_string();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+        let amounts =
+            get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "Swap".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        record.token_sold_mint = amounts.sold.mint.clone();
+        record.token_sold_vault = amounts.sold.vault.clone();
+        record.token_sold_amount = amounts.sold.amount_scaled();
+        record.token_sold_decimals = amounts.sold.decimals;
+
+        record.token_bought_mint = amounts.bought.mint.clone();
+        record.token_bought_vault = amounts.bought.vault.clone();
+        record.token_bought_amount = amounts.bought.amount_scaled();
+        record.token_bought_decimals = amounts.bought.decimals;
+
+        if let Some(info) = get_token_account_info(tx, &amounts.sold.vault) {
+            record.token_sold_vault_reserve = info.post_balance_scaled();
+        }
+        if let Some(info) = get_token_account_info(tx, &amounts.bought.vault) {
+            record.token_bought_vault_reserve = info.post_balance_scaled();
+        }
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/orca_v2/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/orca_v2/mod.rs
@@ -30,14 +30,13 @@ impl DexDecoder for OrcaV2Decoder {
         }
 
         let accounts = ix.accounts();
-        let pool = accounts.get(0)?.to_string();
+        let pool = accounts.first()?.to_string();
         let vault_a = accounts.get(4)?.to_string();
         let vault_b = accounts.get(5)?.to_string();
 
         let outer_idx = ix.instruction_index() as usize;
         let inner_idx = ix.inner_instruction_index() as usize;
-        let amounts =
-            get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
+        let amounts = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
 
         let mut record = SwapRecord::default();
         record.instruction_index = ix.instruction_index();

--- a/jetstreamer-dex-trades/src/decoders/orca_whirlpool/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/orca_whirlpool/idl.rs
@@ -40,7 +40,7 @@ impl SwapEvent {
 
 pub mod events {
     use super::*;
-    use base64::{engine::general_purpose::STANDARD, Engine};
+    use base64::{Engine, engine::general_purpose::STANDARD};
 
     pub fn decode_swap_event_from_log(data: &str) -> Option<SwapEvent> {
         let bytes = STANDARD.decode(data).ok()?;

--- a/jetstreamer-dex-trades/src/decoders/orca_whirlpool/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/orca_whirlpool/idl.rs
@@ -1,0 +1,52 @@
+use borsh::BorshDeserialize;
+use solana_address::Address;
+
+pub const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+pub const SWAP_V2_DISC: [u8; 8] = [43, 4, 237, 11, 26, 201, 30, 98];
+pub const TWO_HOP_SWAP_DISC: [u8; 8] = [195, 140, 249, 166, 220, 94, 30, 64];
+pub const TWO_HOP_SWAP_V2_DISC: [u8; 8] = [194, 225, 185, 112, 203, 248, 38, 95];
+
+pub const SWAP_EVENT_DISC: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
+
+#[derive(Debug, Clone, BorshDeserialize)]
+pub struct SwapEvent {
+    pub pool_state: [u8; 32],
+    pub sender: [u8; 32],
+    pub token_account_0: [u8; 32],
+    pub token_account_1: [u8; 32],
+    pub amount_0: u64,
+    pub transfer_fee_0: u64,
+    pub amount_1: u64,
+    pub transfer_fee_1: u64,
+    pub zero_for_one: bool,
+    pub sqrt_price_x64: u128,
+    pub liquidity: u128,
+    pub tick: i32,
+}
+
+impl SwapEvent {
+    pub fn pool_state_str(&self) -> String {
+        Address::new_from_array(self.pool_state).to_string()
+    }
+
+    pub fn token_account_0_str(&self) -> String {
+        Address::new_from_array(self.token_account_0).to_string()
+    }
+
+    pub fn token_account_1_str(&self) -> String {
+        Address::new_from_array(self.token_account_1).to_string()
+    }
+}
+
+pub mod events {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine};
+
+    pub fn decode_swap_event_from_log(data: &str) -> Option<SwapEvent> {
+        let bytes = STANDARD.decode(data).ok()?;
+        if bytes.len() < 8 || bytes[..8] != SWAP_EVENT_DISC {
+            return None;
+        }
+        SwapEvent::try_from_slice(&bytes[8..]).ok()
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/orca_whirlpool/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/orca_whirlpool/mod.rs
@@ -1,0 +1,355 @@
+pub mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::log_parser::LogParser;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+use std::collections::{HashMap, VecDeque};
+use std::sync::RwLock;
+
+const PROGRAM_ID: &str = "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc";
+
+// swap: pool at accounts[2], vault_a=4, vault_b=6
+const SWAP_POOL_IDX: usize = 2;
+const SWAP_VAULT_A_IDX: usize = 4;
+const SWAP_VAULT_B_IDX: usize = 6;
+
+// swapV2: pool at accounts[4], vault_a=8, vault_b=10
+const SWAP_V2_POOL_IDX: usize = 4;
+const SWAP_V2_VAULT_A_IDX: usize = 8;
+const SWAP_V2_VAULT_B_IDX: usize = 10;
+
+// twoHopSwap: pool_one=2, vault_one_a=5, vault_one_b=7, pool_two=3, vault_two_a=9, vault_two_b=11
+const TWO_HOP_POOL_ONE_IDX: usize = 2;
+const TWO_HOP_V1A_IDX: usize = 5;
+const TWO_HOP_V1B_IDX: usize = 7;
+const TWO_HOP_POOL_TWO_IDX: usize = 3;
+const TWO_HOP_V2A_IDX: usize = 9;
+const TWO_HOP_V2B_IDX: usize = 11;
+
+// twoHopSwapV2: pool_one=0, pool_two=1
+const TWO_HOP_V2_POOL_ONE_IDX: usize = 0;
+const TWO_HOP_V2_V1A_IDX: usize = 9;
+const TWO_HOP_V2_V1B_IDX: usize = 10;
+const TWO_HOP_V2_POOL_TWO_IDX: usize = 1;
+const TWO_HOP_V2_V2A_IDX: usize = 11;
+const TWO_HOP_V2_V2B_IDX: usize = 12;
+
+struct EventCache {
+    events: VecDeque<idl::SwapEvent>,
+    truncated: bool,
+}
+
+pub struct OrcaWhirlpoolDecoder {
+    cache: RwLock<HashMap<String, EventCache>>,
+}
+
+impl OrcaWhirlpoolDecoder {
+    pub fn new() -> Self {
+        Self {
+            cache: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn pop_event(&self, tx_id: &str) -> Option<idl::SwapEvent> {
+        let mut cache = self.cache.write().unwrap();
+        cache.get_mut(tx_id).and_then(|c| c.events.pop_front())
+    }
+
+    fn is_truncated(&self, tx_id: &str) -> bool {
+        let cache = self.cache.read().unwrap();
+        cache.get(tx_id).map(|c| c.truncated).unwrap_or(false)
+    }
+
+    fn decode_from_event(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        instruction_type: &str,
+        event: &idl::SwapEvent,
+    ) -> Option<SwapRecord> {
+        let pool = event.pool_state_str();
+        let vault_0 = event.token_account_0_str();
+        let vault_1 = event.token_account_1_str();
+
+        let info_0 = get_token_account_info(tx, &vault_0)?;
+        let info_1 = get_token_account_info(tx, &vault_1)?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = if ix.is_inner() {
+            PROGRAM_ID.to_string()
+        } else {
+            String::new()
+        };
+        record.pool_address = pool;
+        record.sqrt_price = event.sqrt_price_x64.to_string();
+        record.is_base_to_quote = Some(event.zero_for_one);
+
+        if event.zero_for_one {
+            record.token_sold_mint = info_0.mint.clone();
+            record.token_sold_vault = vault_0;
+            record.token_sold_amount =
+                event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
+            record.token_sold_decimals = info_0.decimals;
+            record.token_sold_vault_reserve = info_0.post_balance_scaled();
+
+            record.token_bought_mint = info_1.mint.clone();
+            record.token_bought_vault = vault_1;
+            record.token_bought_amount =
+                event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
+            record.token_bought_decimals = info_1.decimals;
+            record.token_bought_vault_reserve = info_1.post_balance_scaled();
+        } else {
+            record.token_sold_mint = info_1.mint.clone();
+            record.token_sold_vault = vault_1;
+            record.token_sold_amount =
+                event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
+            record.token_sold_decimals = info_1.decimals;
+            record.token_sold_vault_reserve = info_1.post_balance_scaled();
+
+            record.token_bought_mint = info_0.mint.clone();
+            record.token_bought_vault = vault_0;
+            record.token_bought_amount =
+                event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
+            record.token_bought_decimals = info_0.decimals;
+            record.token_bought_vault_reserve = info_0.post_balance_scaled();
+        }
+
+        Some(record)
+    }
+
+    fn decode_from_transfers(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        instruction_type: &str,
+        pool_idx: usize,
+        vault_a_idx: usize,
+        vault_b_idx: usize,
+    ) -> Option<SwapRecord> {
+        let accounts = ix.accounts();
+        let pool = accounts.get(pool_idx)?;
+        let vault_a = accounts.get(vault_a_idx)?;
+        let vault_b = accounts.get(vault_b_idx)?;
+
+        let swap = get_swap_amounts(
+            tx,
+            ix.instruction_index() as usize,
+            ix.inner_instruction_index() as usize,
+            &vault_a.to_string(),
+            &vault_b.to_string(),
+            None,
+            false,
+        )?;
+
+        let bought_reserve = get_token_account_info(tx, &swap.bought.vault)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        let sold_reserve = get_token_account_info(tx, &swap.sold.vault)
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = if ix.is_inner() {
+            PROGRAM_ID.to_string()
+        } else {
+            String::new()
+        };
+        record.pool_address = pool.to_string();
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_sold_vault_reserve = sold_reserve;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+        record.token_bought_vault_reserve = bought_reserve;
+
+        Some(record)
+    }
+}
+
+impl DexDecoder for OrcaWhirlpoolDecoder {
+    fn name(&self) -> &'static str {
+        "Orca Whirlpool"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn on_transaction_start(&self, tx: &TransactionData) {
+        let logs = tx.get_logs();
+        let truncated = LogParser::is_truncated(&logs);
+
+        let data_by_pos = LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
+        let mut sorted: Vec<(String, String)> = Vec::new();
+        for (pos, entries) in &data_by_pos {
+            for entry in entries {
+                sorted.push((pos.clone(), entry.clone()));
+            }
+        }
+        sorted.sort_by(|a, b| parse_position(&a.0).cmp(&parse_position(&b.0)));
+
+        let mut events = VecDeque::new();
+        for (_pos, data) in sorted {
+            if let Some(event) = idl::events::decode_swap_event_from_log(&data) {
+                events.push_back(event);
+            }
+        }
+
+        let tx_id = tx.signature.to_string();
+        let mut cache = self.cache.write().unwrap();
+        cache.insert(tx_id, EventCache { events, truncated });
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 {
+            return None;
+        }
+
+        let (instruction_type, pool_idx, vault_a_idx, vault_b_idx) = match &data[..8] {
+            d if d == idl::SWAP_DISC => ("swap", SWAP_POOL_IDX, SWAP_VAULT_A_IDX, SWAP_VAULT_B_IDX),
+            d if d == idl::SWAP_V2_DISC => (
+                "swapV2",
+                SWAP_V2_POOL_IDX,
+                SWAP_V2_VAULT_A_IDX,
+                SWAP_V2_VAULT_B_IDX,
+            ),
+            _ => return None,
+        };
+
+        let tx_id = tx.signature.to_string();
+
+        if let Some(event) = self.pop_event(&tx_id) {
+            if let Some(record) =
+                self.decode_from_event(tx, ix, outer_program, instruction_type, &event)
+            {
+                return Some(record);
+            }
+        }
+
+        self.decode_from_transfers(
+            tx,
+            ix,
+            outer_program,
+            instruction_type,
+            pool_idx,
+            vault_a_idx,
+            vault_b_idx,
+        )
+    }
+
+    fn decode_instructions(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Vec<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 {
+            return Vec::new();
+        }
+
+        let hops: &[(
+            &str,
+            usize,
+            usize,
+            usize,
+            usize,
+            usize,
+            usize,
+        )] = match &data[..8] {
+            d if d == idl::TWO_HOP_SWAP_DISC => &[(
+                "twoHopSwap",
+                TWO_HOP_POOL_ONE_IDX,
+                TWO_HOP_V1A_IDX,
+                TWO_HOP_V1B_IDX,
+                TWO_HOP_POOL_TWO_IDX,
+                TWO_HOP_V2A_IDX,
+                TWO_HOP_V2B_IDX,
+            )],
+            d if d == idl::TWO_HOP_SWAP_V2_DISC => &[(
+                "twoHopSwapV2",
+                TWO_HOP_V2_POOL_ONE_IDX,
+                TWO_HOP_V2_V1A_IDX,
+                TWO_HOP_V2_V1B_IDX,
+                TWO_HOP_V2_POOL_TWO_IDX,
+                TWO_HOP_V2_V2A_IDX,
+                TWO_HOP_V2_V2B_IDX,
+            )],
+            _ => {
+                return self
+                    .decode_instruction(tx, ix, outer_program)
+                    .into_iter()
+                    .collect();
+            }
+        };
+
+        let (instruction_type, p1, v1a, v1b, p2, v2a, v2b) = hops[0];
+        let tx_id = tx.signature.to_string();
+        let mut records = Vec::new();
+
+        for &(pool_idx, va_idx, vb_idx) in &[(p1, v1a, v1b), (p2, v2a, v2b)] {
+            if let Some(event) = self.pop_event(&tx_id) {
+                if let Some(record) =
+                    self.decode_from_event(tx, ix, outer_program, instruction_type, &event)
+                {
+                    records.push(record);
+                    continue;
+                }
+            }
+
+            if let Some(record) = self.decode_from_transfers(
+                tx,
+                ix,
+                outer_program,
+                instruction_type,
+                pool_idx,
+                va_idx,
+                vb_idx,
+            ) {
+                records.push(record);
+            }
+        }
+
+        records
+    }
+
+    fn on_transaction_end(&self, tx_id: &str) {
+        let mut cache = self.cache.write().unwrap();
+        cache.remove(tx_id);
+    }
+}
+
+fn parse_position(pos: &str) -> (usize, usize) {
+    let mut parts = pos.split('.');
+    let outer = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let inner = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (outer, inner)
+}

--- a/jetstreamer-dex-trades/src/decoders/orca_whirlpool/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/orca_whirlpool/mod.rs
@@ -40,11 +40,17 @@ const TWO_HOP_V2_V2B_IDX: usize = 12;
 
 struct EventCache {
     events: VecDeque<idl::SwapEvent>,
-    truncated: bool,
+    _truncated: bool,
 }
 
 pub struct OrcaWhirlpoolDecoder {
     cache: RwLock<HashMap<String, EventCache>>,
+}
+
+impl Default for OrcaWhirlpoolDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl OrcaWhirlpoolDecoder {
@@ -57,11 +63,6 @@ impl OrcaWhirlpoolDecoder {
     fn pop_event(&self, tx_id: &str) -> Option<idl::SwapEvent> {
         let mut cache = self.cache.write().unwrap();
         cache.get_mut(tx_id).and_then(|c| c.events.pop_front())
-    }
-
-    fn is_truncated(&self, tx_id: &str) -> bool {
-        let cache = self.cache.read().unwrap();
-        cache.get(tx_id).map(|c| c.truncated).unwrap_or(false)
     }
 
     fn decode_from_event(
@@ -97,29 +98,25 @@ impl OrcaWhirlpoolDecoder {
         if event.zero_for_one {
             record.token_sold_mint = info_0.mint.clone();
             record.token_sold_vault = vault_0;
-            record.token_sold_amount =
-                event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
+            record.token_sold_amount = event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
             record.token_sold_decimals = info_0.decimals;
             record.token_sold_vault_reserve = info_0.post_balance_scaled();
 
             record.token_bought_mint = info_1.mint.clone();
             record.token_bought_vault = vault_1;
-            record.token_bought_amount =
-                event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
+            record.token_bought_amount = event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
             record.token_bought_decimals = info_1.decimals;
             record.token_bought_vault_reserve = info_1.post_balance_scaled();
         } else {
             record.token_sold_mint = info_1.mint.clone();
             record.token_sold_vault = vault_1;
-            record.token_sold_amount =
-                event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
+            record.token_sold_amount = event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
             record.token_sold_decimals = info_1.decimals;
             record.token_sold_vault_reserve = info_1.post_balance_scaled();
 
             record.token_bought_mint = info_0.mint.clone();
             record.token_bought_vault = vault_0;
-            record.token_bought_amount =
-                event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
+            record.token_bought_amount = event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
             record.token_bought_decimals = info_0.decimals;
             record.token_bought_vault_reserve = info_0.post_balance_scaled();
         }
@@ -219,7 +216,13 @@ impl DexDecoder for OrcaWhirlpoolDecoder {
 
         let tx_id = tx.signature.to_string();
         let mut cache = self.cache.write().unwrap();
-        cache.insert(tx_id, EventCache { events, truncated });
+        cache.insert(
+            tx_id,
+            EventCache {
+                events,
+                _truncated: truncated,
+            },
+        );
     }
 
     fn decode_instruction(
@@ -246,12 +249,11 @@ impl DexDecoder for OrcaWhirlpoolDecoder {
 
         let tx_id = tx.signature.to_string();
 
-        if let Some(event) = self.pop_event(&tx_id) {
-            if let Some(record) =
+        if let Some(event) = self.pop_event(&tx_id)
+            && let Some(record) =
                 self.decode_from_event(tx, ix, outer_program, instruction_type, &event)
-            {
-                return Some(record);
-            }
+        {
+            return Some(record);
         }
 
         self.decode_from_transfers(
@@ -276,15 +278,7 @@ impl DexDecoder for OrcaWhirlpoolDecoder {
             return Vec::new();
         }
 
-        let hops: &[(
-            &str,
-            usize,
-            usize,
-            usize,
-            usize,
-            usize,
-            usize,
-        )] = match &data[..8] {
+        let hops: &[(&str, usize, usize, usize, usize, usize, usize)] = match &data[..8] {
             d if d == idl::TWO_HOP_SWAP_DISC => &[(
                 "twoHopSwap",
                 TWO_HOP_POOL_ONE_IDX,
@@ -316,13 +310,12 @@ impl DexDecoder for OrcaWhirlpoolDecoder {
         let mut records = Vec::new();
 
         for &(pool_idx, va_idx, vb_idx) in &[(p1, v1a, v1b), (p2, v2a, v2b)] {
-            if let Some(event) = self.pop_event(&tx_id) {
-                if let Some(record) =
+            if let Some(event) = self.pop_event(&tx_id)
+                && let Some(record) =
                     self.decode_from_event(tx, ix, outer_program, instruction_type, &event)
-                {
-                    records.push(record);
-                    continue;
-                }
+            {
+                records.push(record);
+                continue;
             }
 
             if let Some(record) = self.decode_from_transfers(

--- a/jetstreamer-dex-trades/src/decoders/pancakeswap_clmm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/pancakeswap_clmm/idl.rs
@@ -1,0 +1,19 @@
+use borsh::BorshDeserialize;
+
+/// SwapEvent emitted by CLMM programs (PancakeSwap, Byreal, Raydium CLMM).
+/// Borsh-serialized after the 8-byte Anchor event discriminator.
+#[derive(Debug, Clone, BorshDeserialize)]
+pub struct SwapEvent {
+    pub pool_state: [u8; 32],
+    pub sender: [u8; 32],
+    pub token_account_0: [u8; 32],
+    pub token_account_1: [u8; 32],
+    pub amount_0: u64,
+    pub transfer_fee_0: u64,
+    pub amount_1: u64,
+    pub transfer_fee_1: u64,
+    pub zero_for_one: bool,
+    pub sqrt_price_x64: u128,
+    pub liquidity: u128,
+    pub tick: i32,
+}

--- a/jetstreamer-dex-trades/src/decoders/pancakeswap_clmm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/pancakeswap_clmm/mod.rs
@@ -2,10 +2,10 @@ pub mod idl;
 
 use crate::instruction_iter::Instruction;
 use crate::log_parser::LogParser;
+use crate::registry::DexDecoder;
 use crate::token_transfers::{get_swap_amounts, get_token_account_info};
 use crate::transaction_ext::TransactionExt;
 use crate::types::SwapRecord;
-use crate::registry::DexDecoder;
 use borsh::BorshDeserialize;
 use jetstreamer_firehose::firehose::TransactionData;
 use solana_address::Address;
@@ -158,10 +158,12 @@ fn decode_from_transfers(
 
     let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
     let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
-    record.token_sold_vault_reserve =
-        sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
-    record.token_bought_vault_reserve =
-        bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+    record.token_sold_vault_reserve = sold_vault_info
+        .map(|i| i.post_balance_scaled())
+        .unwrap_or(0.0);
+    record.token_bought_vault_reserve = bought_vault_info
+        .map(|i| i.post_balance_scaled())
+        .unwrap_or(0.0);
 
     Some(record)
 }
@@ -221,10 +223,12 @@ fn build_record_from_event(
 
     let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
     let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
-    record.token_sold_vault_reserve =
-        sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
-    record.token_bought_vault_reserve =
-        bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+    record.token_sold_vault_reserve = sold_vault_info
+        .map(|i| i.post_balance_scaled())
+        .unwrap_or(0.0);
+    record.token_bought_vault_reserve = bought_vault_info
+        .map(|i| i.post_balance_scaled())
+        .unwrap_or(0.0);
 
     Some(record)
 }

--- a/jetstreamer-dex-trades/src/decoders/pancakeswap_clmm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/pancakeswap_clmm/mod.rs
@@ -1,0 +1,230 @@
+pub mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::log_parser::LogParser;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use crate::registry::DexDecoder;
+use borsh::BorshDeserialize;
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+
+const PROGRAM_ID: &str = "HpNfyc2Saw7RKkQd8nEL4khUcuPhQ7WwY1B2qjx8jxFq";
+
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+const SWAP_V2_DISC: [u8; 8] = [43, 4, 237, 11, 26, 201, 30, 98];
+
+/// Anchor self-CPI event wrapper discriminator.
+const EVENT_WRAPPER_DISC: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+
+pub struct PancakeSwapClmmDecoder;
+
+impl DexDecoder for PancakeSwapClmmDecoder {
+    fn name(&self) -> &'static str {
+        "PancakeSwap CLMM"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let accounts = ix.accounts();
+
+        let instruction_type = if ix.has_discriminator(&SWAP_DISC) {
+            "Swap"
+        } else if ix.has_discriminator(&SWAP_V2_DISC) {
+            "SwapV2"
+        } else {
+            return try_decode_event(tx, ix, outer_program);
+        };
+
+        if accounts.len() < 2 {
+            return None;
+        }
+
+        let pool = accounts[1].to_string();
+
+        if let Some(record) = try_decode_from_logs(tx, ix, outer_program, &pool, instruction_type) {
+            return Some(record);
+        }
+
+        decode_from_transfers(tx, ix, outer_program, &pool, instruction_type)
+    }
+}
+
+fn try_decode_event(
+    tx: &TransactionData,
+    ix: &Instruction,
+    outer_program: &str,
+) -> Option<SwapRecord> {
+    let data = ix.data();
+    if data.len() < 16 {
+        return None;
+    }
+    if data[..8] != EVENT_WRAPPER_DISC {
+        return None;
+    }
+
+    let event = idl::SwapEvent::try_from_slice(&data[8..]).ok()?;
+    build_record_from_event(tx, ix, outer_program, &event)
+}
+
+fn try_decode_from_logs(
+    tx: &TransactionData,
+    ix: &Instruction,
+    outer_program: &str,
+    _pool: &str,
+    instruction_type: &str,
+) -> Option<SwapRecord> {
+    let logs = tx.get_logs();
+    let data_events = LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
+
+    let position = if ix.is_inner() {
+        format!(
+            "{}.{}",
+            ix.instruction_index(),
+            ix.inner_instruction_index()
+        )
+    } else {
+        ix.instruction_index().to_string()
+    };
+
+    let event_data_list = data_events.get(&position)?;
+
+    for encoded in event_data_list {
+        if let Ok(raw) = base64::Engine::decode(&base64::engine::general_purpose::STANDARD, encoded)
+        {
+            if raw.len() < 8 {
+                continue;
+            }
+            if let Ok(event) = idl::SwapEvent::try_from_slice(&raw[8..]) {
+                let pool_addr = Address::new_from_array(event.pool_state);
+                let mut record = build_record_from_event(tx, ix, outer_program, &event)?;
+                record.pool_address = pool_addr.to_string();
+                record.instruction_type = instruction_type.to_string();
+                return Some(record);
+            }
+        }
+    }
+
+    None
+}
+
+fn decode_from_transfers(
+    tx: &TransactionData,
+    ix: &Instruction,
+    outer_program: &str,
+    pool: &str,
+    instruction_type: &str,
+) -> Option<SwapRecord> {
+    let accounts = ix.accounts();
+    if accounts.len() < 10 {
+        return None;
+    }
+
+    let vault_0 = accounts[4].to_string();
+    let vault_1 = accounts[5].to_string();
+
+    let outer_idx = ix.instruction_index() as usize;
+    let inner_idx = ix.inner_instruction_index() as usize;
+
+    let amounts = get_swap_amounts(tx, outer_idx, inner_idx, &vault_0, &vault_1, None, false)?;
+
+    let mut record = SwapRecord::default();
+    record.instruction_index = ix.instruction_index();
+    record.inner_instruction_index = ix.inner_instruction_index();
+    record.is_inner_instruction = ix.is_inner();
+    record.instruction_type = instruction_type.to_string();
+    record.outer_program = outer_program.to_string();
+    record.inner_program = PROGRAM_ID.to_string();
+    record.pool_address = pool.to_string();
+
+    record.token_sold_mint = amounts.sold.mint.clone();
+    record.token_sold_vault = amounts.sold.vault.clone();
+    record.token_sold_amount = amounts.sold.amount_scaled();
+    record.token_sold_decimals = amounts.sold.decimals;
+
+    record.token_bought_mint = amounts.bought.mint.clone();
+    record.token_bought_vault = amounts.bought.vault.clone();
+    record.token_bought_amount = amounts.bought.amount_scaled();
+    record.token_bought_decimals = amounts.bought.decimals;
+
+    let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
+    let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
+    record.token_sold_vault_reserve =
+        sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+    record.token_bought_vault_reserve =
+        bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+
+    Some(record)
+}
+
+fn build_record_from_event(
+    tx: &TransactionData,
+    ix: &Instruction,
+    outer_program: &str,
+    event: &idl::SwapEvent,
+) -> Option<SwapRecord> {
+    let pool = Address::new_from_array(event.pool_state);
+    let vault_0 = Address::new_from_array(event.token_account_0);
+    let vault_1 = Address::new_from_array(event.token_account_1);
+
+    let info_0 = get_token_account_info(tx, &vault_0.to_string());
+    let info_1 = get_token_account_info(tx, &vault_1.to_string());
+
+    let decimals_0 = info_0.as_ref().map(|i| i.decimals).unwrap_or(6);
+    let decimals_1 = info_1.as_ref().map(|i| i.decimals).unwrap_or(6);
+    let mint_0 = info_0.as_ref().map(|i| i.mint.clone()).unwrap_or_default();
+    let mint_1 = info_1.as_ref().map(|i| i.mint.clone()).unwrap_or_default();
+
+    let amount_0 = event.amount_0 as f64 / 10f64.powi(decimals_0 as i32);
+    let amount_1 = event.amount_1 as f64 / 10f64.powi(decimals_1 as i32);
+
+    let mut record = SwapRecord::default();
+    record.instruction_index = ix.instruction_index();
+    record.inner_instruction_index = ix.inner_instruction_index();
+    record.is_inner_instruction = ix.is_inner();
+    record.instruction_type = "Swap".to_string();
+    record.outer_program = outer_program.to_string();
+    record.inner_program = PROGRAM_ID.to_string();
+    record.pool_address = pool.to_string();
+
+    record.sqrt_price = event.sqrt_price_x64.to_string();
+    record.is_base_to_quote = Some(event.zero_for_one);
+
+    if event.zero_for_one {
+        record.token_sold_mint = mint_0;
+        record.token_sold_vault = vault_0.to_string();
+        record.token_sold_amount = amount_0;
+        record.token_sold_decimals = decimals_0;
+        record.token_bought_mint = mint_1;
+        record.token_bought_vault = vault_1.to_string();
+        record.token_bought_amount = amount_1;
+        record.token_bought_decimals = decimals_1;
+    } else {
+        record.token_sold_mint = mint_1;
+        record.token_sold_vault = vault_1.to_string();
+        record.token_sold_amount = amount_1;
+        record.token_sold_decimals = decimals_1;
+        record.token_bought_mint = mint_0;
+        record.token_bought_vault = vault_0.to_string();
+        record.token_bought_amount = amount_0;
+        record.token_bought_decimals = decimals_0;
+    }
+
+    let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
+    let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
+    record.token_sold_vault_reserve =
+        sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+    record.token_bought_vault_reserve =
+        bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+
+    Some(record)
+}

--- a/jetstreamer-dex-trades/src/decoders/pump_amm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/pump_amm/idl.rs
@@ -1,0 +1,245 @@
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::{Cursor, Read};
+
+const PUBKEY_LEN: usize = 32;
+
+fn read_pubkey(cursor: &mut Cursor<&[u8]>) -> Option<[u8; 32]> {
+    let mut buf = [0u8; PUBKEY_LEN];
+    cursor.read_exact(&mut buf).ok()?;
+    Some(buf)
+}
+
+fn read_option_pubkey(cursor: &mut Cursor<&[u8]>) -> Option<Option<[u8; 32]>> {
+    let tag = cursor.read_u8().ok()?;
+    if tag == 0 {
+        Some(None)
+    } else {
+        let pk = read_pubkey(cursor)?;
+        Some(Some(pk))
+    }
+}
+
+fn read_option_u64(cursor: &mut Cursor<&[u8]>) -> Option<Option<u64>> {
+    let tag = cursor.read_u8().ok()?;
+    if tag == 0 {
+        Some(None)
+    } else {
+        let val = cursor.read_u64::<LittleEndian>().ok()?;
+        Some(Some(val))
+    }
+}
+
+/// Pump AMM BuyEvent — variable size due to optional coin_creator fields (V0 vs V1).
+#[derive(Debug, Clone)]
+pub struct BuyEvent {
+    pub timestamp: i64,
+    pub base_amount_out: u64,
+    pub max_quote_amount_in: u64,
+    pub user_base_token_reserves: u64,
+    pub user_quote_token_reserves: u64,
+    pub pool_base_token_reserves: u64,
+    pub pool_quote_token_reserves: u64,
+    pub quote_amount_in: u64,
+    pub lp_fee_basis_points: u64,
+    pub lp_fee: u64,
+    pub protocol_fee_basis_points: u64,
+    pub protocol_fee: u64,
+    pub quote_amount_in_with_lp_fee: u64,
+    pub user_quote_amount_in_with_fees: u64,
+    pub pool: [u8; 32],
+    pub user: [u8; 32],
+    pub user_base_token_account: [u8; 32],
+    pub user_quote_token_account: [u8; 32],
+    pub protocol_fee_recipient: [u8; 32],
+    pub protocol_fee_recipient_token_account: [u8; 32],
+    // V1 optional fields
+    pub coin_creator: Option<[u8; 32]>,
+    pub coin_creator_fee_basis_points: Option<u64>,
+    pub coin_creator_fee: Option<u64>,
+    pub coin_creator_token_account: Option<[u8; 32]>,
+}
+
+impl BuyEvent {
+    pub fn deserialize(data: &[u8]) -> Option<Self> {
+        let mut cursor = Cursor::new(data);
+
+        let timestamp = cursor.read_i64::<LittleEndian>().ok()?;
+        let base_amount_out = cursor.read_u64::<LittleEndian>().ok()?;
+        let max_quote_amount_in = cursor.read_u64::<LittleEndian>().ok()?;
+        let user_base_token_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+        let user_quote_token_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+        let pool_base_token_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+        let pool_quote_token_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+        let quote_amount_in = cursor.read_u64::<LittleEndian>().ok()?;
+        let lp_fee_basis_points = cursor.read_u64::<LittleEndian>().ok()?;
+        let lp_fee = cursor.read_u64::<LittleEndian>().ok()?;
+        let protocol_fee_basis_points = cursor.read_u64::<LittleEndian>().ok()?;
+        let protocol_fee = cursor.read_u64::<LittleEndian>().ok()?;
+        let quote_amount_in_with_lp_fee = cursor.read_u64::<LittleEndian>().ok()?;
+        let user_quote_amount_in_with_fees = cursor.read_u64::<LittleEndian>().ok()?;
+        let pool = read_pubkey(&mut cursor)?;
+        let user = read_pubkey(&mut cursor)?;
+        let user_base_token_account = read_pubkey(&mut cursor)?;
+        let user_quote_token_account = read_pubkey(&mut cursor)?;
+        let protocol_fee_recipient = read_pubkey(&mut cursor)?;
+        let protocol_fee_recipient_token_account = read_pubkey(&mut cursor)?;
+
+        let coin_creator = read_option_pubkey(&mut cursor).unwrap_or(None);
+        let coin_creator_fee_basis_points = read_option_u64(&mut cursor).unwrap_or(None);
+        let coin_creator_fee = read_option_u64(&mut cursor).unwrap_or(None);
+        let coin_creator_token_account = read_option_pubkey(&mut cursor).unwrap_or(None);
+
+        Some(Self {
+            timestamp,
+            base_amount_out,
+            max_quote_amount_in,
+            user_base_token_reserves,
+            user_quote_token_reserves,
+            pool_base_token_reserves,
+            pool_quote_token_reserves,
+            quote_amount_in,
+            lp_fee_basis_points,
+            lp_fee,
+            protocol_fee_basis_points,
+            protocol_fee,
+            quote_amount_in_with_lp_fee,
+            user_quote_amount_in_with_fees,
+            pool,
+            user,
+            user_base_token_account,
+            user_quote_token_account,
+            protocol_fee_recipient,
+            protocol_fee_recipient_token_account,
+            coin_creator,
+            coin_creator_fee_basis_points,
+            coin_creator_fee,
+            coin_creator_token_account,
+        })
+    }
+}
+
+/// Pump AMM SellEvent — variable size due to optional coin_creator fields.
+#[derive(Debug, Clone)]
+pub struct SellEvent {
+    pub timestamp: i64,
+    pub base_amount_in: u64,
+    pub min_quote_amount_out: u64,
+    pub user_base_token_reserves: u64,
+    pub user_quote_token_reserves: u64,
+    pub pool_base_token_reserves: u64,
+    pub pool_quote_token_reserves: u64,
+    pub quote_amount_out: u64,
+    pub lp_fee_basis_points: u64,
+    pub lp_fee: u64,
+    pub protocol_fee_basis_points: u64,
+    pub protocol_fee: u64,
+    pub quote_amount_out_without_lp_fee: u64,
+    pub user_quote_amount_out_without_fees: u64,
+    pub pool: [u8; 32],
+    pub user: [u8; 32],
+    pub user_base_token_account: [u8; 32],
+    pub user_quote_token_account: [u8; 32],
+    pub protocol_fee_recipient: [u8; 32],
+    pub protocol_fee_recipient_token_account: [u8; 32],
+    // V1 optional fields
+    pub coin_creator: Option<[u8; 32]>,
+    pub coin_creator_fee_basis_points: Option<u64>,
+    pub coin_creator_fee: Option<u64>,
+    pub coin_creator_token_account: Option<[u8; 32]>,
+}
+
+impl SellEvent {
+    pub fn deserialize(data: &[u8]) -> Option<Self> {
+        let mut cursor = Cursor::new(data);
+
+        let timestamp = cursor.read_i64::<LittleEndian>().ok()?;
+        let base_amount_in = cursor.read_u64::<LittleEndian>().ok()?;
+        let min_quote_amount_out = cursor.read_u64::<LittleEndian>().ok()?;
+        let user_base_token_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+        let user_quote_token_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+        let pool_base_token_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+        let pool_quote_token_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+        let quote_amount_out = cursor.read_u64::<LittleEndian>().ok()?;
+        let lp_fee_basis_points = cursor.read_u64::<LittleEndian>().ok()?;
+        let lp_fee = cursor.read_u64::<LittleEndian>().ok()?;
+        let protocol_fee_basis_points = cursor.read_u64::<LittleEndian>().ok()?;
+        let protocol_fee = cursor.read_u64::<LittleEndian>().ok()?;
+        let quote_amount_out_without_lp_fee = cursor.read_u64::<LittleEndian>().ok()?;
+        let user_quote_amount_out_without_fees = cursor.read_u64::<LittleEndian>().ok()?;
+        let pool = read_pubkey(&mut cursor)?;
+        let user = read_pubkey(&mut cursor)?;
+        let user_base_token_account = read_pubkey(&mut cursor)?;
+        let user_quote_token_account = read_pubkey(&mut cursor)?;
+        let protocol_fee_recipient = read_pubkey(&mut cursor)?;
+        let protocol_fee_recipient_token_account = read_pubkey(&mut cursor)?;
+
+        let coin_creator = read_option_pubkey(&mut cursor).unwrap_or(None);
+        let coin_creator_fee_basis_points = read_option_u64(&mut cursor).unwrap_or(None);
+        let coin_creator_fee = read_option_u64(&mut cursor).unwrap_or(None);
+        let coin_creator_token_account = read_option_pubkey(&mut cursor).unwrap_or(None);
+
+        Some(Self {
+            timestamp,
+            base_amount_in,
+            min_quote_amount_out,
+            user_base_token_reserves,
+            user_quote_token_reserves,
+            pool_base_token_reserves,
+            pool_quote_token_reserves,
+            quote_amount_out,
+            lp_fee_basis_points,
+            lp_fee,
+            protocol_fee_basis_points,
+            protocol_fee,
+            quote_amount_out_without_lp_fee,
+            user_quote_amount_out_without_fees,
+            pool,
+            user,
+            user_base_token_account,
+            user_quote_token_account,
+            protocol_fee_recipient,
+            protocol_fee_recipient_token_account,
+            coin_creator,
+            coin_creator_fee_basis_points,
+            coin_creator_fee,
+            coin_creator_token_account,
+        })
+    }
+}
+
+pub mod events {
+    use super::{BuyEvent, SellEvent};
+
+    pub const EVENT_WRAPPER_DISC: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+    pub const BUY_EVENT_DISC: [u8; 8] = [103, 244, 82, 31, 44, 245, 119, 119];
+    pub const SELL_EVENT_DISC: [u8; 8] = [62, 47, 55, 10, 165, 3, 220, 42];
+
+    pub enum TradeEvent {
+        Buy(BuyEvent),
+        Sell(SellEvent),
+    }
+
+    /// Decode a trade event from the self-CPI instruction data.
+    /// Layout: event_wrapper_disc(8) + inner_disc(8) + payload
+    pub fn decode_trade_event(data: &[u8]) -> Option<TradeEvent> {
+        if data.len() < 16 {
+            return None;
+        }
+        if data[..8] != EVENT_WRAPPER_DISC {
+            return None;
+        }
+
+        let inner_disc = &data[8..16];
+        let payload = &data[16..];
+
+        if inner_disc == BUY_EVENT_DISC {
+            let event = BuyEvent::deserialize(payload)?;
+            Some(TradeEvent::Buy(event))
+        } else if inner_disc == SELL_EVENT_DISC {
+            let event = SellEvent::deserialize(payload)?;
+            Some(TradeEvent::Sell(event))
+        } else {
+            None
+        }
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/pump_amm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/pump_amm/idl.rs
@@ -31,6 +31,7 @@ fn read_option_u64(cursor: &mut Cursor<&[u8]>) -> Option<Option<u64>> {
 
 /// Pump AMM BuyEvent — variable size due to optional coin_creator fields (V0 vs V1).
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct BuyEvent {
     pub timestamp: i64,
     pub base_amount_out: u64,
@@ -120,6 +121,7 @@ impl BuyEvent {
 
 /// Pump AMM SellEvent — variable size due to optional coin_creator fields.
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct SellEvent {
     pub timestamp: i64,
     pub base_amount_in: u64,

--- a/jetstreamer-dex-trades/src/decoders/pump_amm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/pump_amm/mod.rs
@@ -1,0 +1,165 @@
+mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::get_token_account_info;
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+
+const PROGRAM_ID: &str = "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA";
+const SOL_MINT: &str = "So11111111111111111111111111111111111111112";
+const SOL_DECIMALS: u8 = 9;
+
+pub struct PumpAmmDecoder;
+
+impl DexDecoder for PumpAmmDecoder {
+    fn name(&self) -> &'static str {
+        "Pump AMM"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        let trade_event = idl::events::decode_trade_event(data)?;
+
+        match trade_event {
+            idl::events::TradeEvent::Buy(event) => {
+                self.decode_buy(tx, ix, outer_program, &event)
+            }
+            idl::events::TradeEvent::Sell(event) => {
+                self.decode_sell(tx, ix, outer_program, &event)
+            }
+        }
+    }
+}
+
+impl PumpAmmDecoder {
+    fn decode_buy(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        event: &idl::BuyEvent,
+    ) -> Option<SwapRecord> {
+        let pool = Address::new_from_array(event.pool);
+        let user = Address::new_from_array(event.user);
+        let user_base_account = Address::new_from_array(event.user_base_token_account);
+        let user_quote_account = Address::new_from_array(event.user_quote_token_account);
+
+        let base_info = get_token_account_info(tx, &user_base_account.to_string());
+        let quote_info = get_token_account_info(tx, &user_quote_account.to_string());
+
+        let base_decimals = base_info.as_ref().map(|i| i.decimals).unwrap_or(6);
+        let quote_decimals = quote_info.as_ref().map(|i| i.decimals).unwrap_or(SOL_DECIMALS);
+        let base_mint = base_info
+            .as_ref()
+            .map(|i| i.mint.clone())
+            .unwrap_or_default();
+        let quote_mint = quote_info
+            .as_ref()
+            .map(|i| i.mint.clone())
+            .unwrap_or_else(|| SOL_MINT.to_string());
+
+        let base_amount = event.base_amount_out as f64 / 10f64.powi(base_decimals as i32);
+        let quote_amount =
+            event.quote_amount_in as f64 / 10f64.powi(quote_decimals as i32);
+
+        let pool_base_reserve =
+            event.pool_base_token_reserves as f64 / 10f64.powi(base_decimals as i32);
+        let pool_quote_reserve =
+            event.pool_quote_token_reserves as f64 / 10f64.powi(quote_decimals as i32);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "Buy".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool.to_string();
+        record.signer = user.to_string();
+
+        record.token_bought_mint = base_mint;
+        record.token_bought_vault = user_base_account.to_string();
+        record.token_bought_amount = base_amount;
+        record.token_bought_decimals = base_decimals;
+        record.token_bought_vault_reserve = pool_base_reserve;
+
+        record.token_sold_mint = quote_mint;
+        record.token_sold_vault = user_quote_account.to_string();
+        record.token_sold_amount = quote_amount;
+        record.token_sold_decimals = quote_decimals;
+        record.token_sold_vault_reserve = pool_quote_reserve;
+
+        Some(record)
+    }
+
+    fn decode_sell(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        event: &idl::SellEvent,
+    ) -> Option<SwapRecord> {
+        let pool = Address::new_from_array(event.pool);
+        let user = Address::new_from_array(event.user);
+        let user_base_account = Address::new_from_array(event.user_base_token_account);
+        let user_quote_account = Address::new_from_array(event.user_quote_token_account);
+
+        let base_info = get_token_account_info(tx, &user_base_account.to_string());
+        let quote_info = get_token_account_info(tx, &user_quote_account.to_string());
+
+        let base_decimals = base_info.as_ref().map(|i| i.decimals).unwrap_or(6);
+        let quote_decimals = quote_info.as_ref().map(|i| i.decimals).unwrap_or(SOL_DECIMALS);
+        let base_mint = base_info
+            .as_ref()
+            .map(|i| i.mint.clone())
+            .unwrap_or_default();
+        let quote_mint = quote_info
+            .as_ref()
+            .map(|i| i.mint.clone())
+            .unwrap_or_else(|| SOL_MINT.to_string());
+
+        let base_amount = event.base_amount_in as f64 / 10f64.powi(base_decimals as i32);
+        let quote_amount =
+            event.quote_amount_out as f64 / 10f64.powi(quote_decimals as i32);
+
+        let pool_base_reserve =
+            event.pool_base_token_reserves as f64 / 10f64.powi(base_decimals as i32);
+        let pool_quote_reserve =
+            event.pool_quote_token_reserves as f64 / 10f64.powi(quote_decimals as i32);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = "Sell".to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool.to_string();
+        record.signer = user.to_string();
+
+        record.token_bought_mint = quote_mint;
+        record.token_bought_vault = user_quote_account.to_string();
+        record.token_bought_amount = quote_amount;
+        record.token_bought_decimals = quote_decimals;
+        record.token_bought_vault_reserve = pool_quote_reserve;
+
+        record.token_sold_mint = base_mint;
+        record.token_sold_vault = user_base_account.to_string();
+        record.token_sold_amount = base_amount;
+        record.token_sold_decimals = base_decimals;
+        record.token_sold_vault_reserve = pool_base_reserve;
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/pump_amm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/pump_amm/mod.rs
@@ -32,12 +32,8 @@ impl DexDecoder for PumpAmmDecoder {
         let trade_event = idl::events::decode_trade_event(data)?;
 
         match trade_event {
-            idl::events::TradeEvent::Buy(event) => {
-                self.decode_buy(tx, ix, outer_program, &event)
-            }
-            idl::events::TradeEvent::Sell(event) => {
-                self.decode_sell(tx, ix, outer_program, &event)
-            }
+            idl::events::TradeEvent::Buy(event) => self.decode_buy(tx, ix, outer_program, &event),
+            idl::events::TradeEvent::Sell(event) => self.decode_sell(tx, ix, outer_program, &event),
         }
     }
 }
@@ -59,7 +55,10 @@ impl PumpAmmDecoder {
         let quote_info = get_token_account_info(tx, &user_quote_account.to_string());
 
         let base_decimals = base_info.as_ref().map(|i| i.decimals).unwrap_or(6);
-        let quote_decimals = quote_info.as_ref().map(|i| i.decimals).unwrap_or(SOL_DECIMALS);
+        let quote_decimals = quote_info
+            .as_ref()
+            .map(|i| i.decimals)
+            .unwrap_or(SOL_DECIMALS);
         let base_mint = base_info
             .as_ref()
             .map(|i| i.mint.clone())
@@ -70,8 +69,7 @@ impl PumpAmmDecoder {
             .unwrap_or_else(|| SOL_MINT.to_string());
 
         let base_amount = event.base_amount_out as f64 / 10f64.powi(base_decimals as i32);
-        let quote_amount =
-            event.quote_amount_in as f64 / 10f64.powi(quote_decimals as i32);
+        let quote_amount = event.quote_amount_in as f64 / 10f64.powi(quote_decimals as i32);
 
         let pool_base_reserve =
             event.pool_base_token_reserves as f64 / 10f64.powi(base_decimals as i32);
@@ -119,7 +117,10 @@ impl PumpAmmDecoder {
         let quote_info = get_token_account_info(tx, &user_quote_account.to_string());
 
         let base_decimals = base_info.as_ref().map(|i| i.decimals).unwrap_or(6);
-        let quote_decimals = quote_info.as_ref().map(|i| i.decimals).unwrap_or(SOL_DECIMALS);
+        let quote_decimals = quote_info
+            .as_ref()
+            .map(|i| i.decimals)
+            .unwrap_or(SOL_DECIMALS);
         let base_mint = base_info
             .as_ref()
             .map(|i| i.mint.clone())
@@ -130,8 +131,7 @@ impl PumpAmmDecoder {
             .unwrap_or_else(|| SOL_MINT.to_string());
 
         let base_amount = event.base_amount_in as f64 / 10f64.powi(base_decimals as i32);
-        let quote_amount =
-            event.quote_amount_out as f64 / 10f64.powi(quote_decimals as i32);
+        let quote_amount = event.quote_amount_out as f64 / 10f64.powi(quote_decimals as i32);
 
         let pool_base_reserve =
             event.pool_base_token_reserves as f64 / 10f64.powi(base_decimals as i32);

--- a/jetstreamer-dex-trades/src/decoders/pump_fun/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/pump_fun/idl.rs
@@ -1,0 +1,96 @@
+use byteorder::{LittleEndian, ReadBytesExt};
+use std::io::Cursor;
+
+const PUBKEY_LEN: usize = 32;
+
+#[derive(Debug, Clone)]
+pub struct TradeEvent {
+    pub mint: [u8; 32],
+    pub sol_amount: u64,
+    pub token_amount: u64,
+    pub is_buy: bool,
+    pub user: [u8; 32],
+    pub timestamp: i64,
+    pub virtual_sol_reserves: u64,
+    pub virtual_token_reserves: u64,
+    pub real_sol_reserves: u64,
+    pub real_token_reserves: u64,
+}
+
+impl TradeEvent {
+    /// Deserialize from raw bytes (after stripping discriminator).
+    /// Layout: mint(32) + sol_amount(8) + token_amount(8) + is_buy(1)
+    ///       + user(32) + timestamp(8) + virtual_sol(8) + virtual_token(8)
+    ///       + real_sol(8) + real_token(8) = 121 bytes
+    pub fn deserialize(data: &[u8]) -> Option<Self> {
+        if data.len() < 121 {
+            return None;
+        }
+
+        let mut cursor = Cursor::new(data);
+
+        let mut mint = [0u8; PUBKEY_LEN];
+        std::io::Read::read_exact(&mut cursor, &mut mint).ok()?;
+
+        let sol_amount = cursor.read_u64::<LittleEndian>().ok()?;
+        let token_amount = cursor.read_u64::<LittleEndian>().ok()?;
+        let is_buy = cursor.read_u8().ok()? != 0;
+
+        let mut user = [0u8; PUBKEY_LEN];
+        std::io::Read::read_exact(&mut cursor, &mut user).ok()?;
+
+        let timestamp = cursor.read_i64::<LittleEndian>().ok()?;
+        let virtual_sol_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+        let virtual_token_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+        let real_sol_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+        let real_token_reserves = cursor.read_u64::<LittleEndian>().ok()?;
+
+        Some(Self {
+            mint,
+            sol_amount,
+            token_amount,
+            is_buy,
+            user,
+            timestamp,
+            virtual_sol_reserves,
+            virtual_token_reserves,
+            real_sol_reserves,
+            real_token_reserves,
+        })
+    }
+}
+
+pub mod events {
+    use super::TradeEvent;
+
+    /// Anchor self-CPI event wrapper discriminator (first 8 bytes of sha256("anchor:event"))
+    pub const EVENT_WRAPPER_DISC: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+    /// Buy event discriminator
+    pub const BUY_EVENT_DISC: [u8; 8] = [189, 23, 183, 97, 220, 167, 55, 174];
+    /// Sell event discriminator
+    pub const SELL_EVENT_DISC: [u8; 8] = [33, 108, 13, 221, 235, 37, 153, 28];
+
+    /// Decode a trade event from the inner CPI instruction data.
+    /// The data starts with the event wrapper discriminator (8 bytes), then
+    /// the inner event discriminator (8 bytes), then the event payload.
+    pub fn decode_trade_event(data: &[u8]) -> Option<(TradeEvent, bool)> {
+        if data.len() < 16 {
+            return None;
+        }
+        if data[..8] != EVENT_WRAPPER_DISC {
+            return None;
+        }
+
+        let inner_disc = &data[8..16];
+        let is_buy = if inner_disc == BUY_EVENT_DISC {
+            true
+        } else if inner_disc == SELL_EVENT_DISC {
+            false
+        } else {
+            return None;
+        };
+
+        let event = TradeEvent::deserialize(&data[16..])?;
+        Some((event, is_buy))
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/pump_fun/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/pump_fun/idl.rs
@@ -4,6 +4,7 @@ use std::io::Cursor;
 const PUBKEY_LEN: usize = 32;
 
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 pub struct TradeEvent {
     pub mint: [u8; 32],
     pub sol_amount: u64,

--- a/jetstreamer-dex-trades/src/decoders/pump_fun/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/pump_fun/mod.rs
@@ -49,10 +49,8 @@ impl DexDecoder for PumpFunDecoder {
             user.to_string()
         };
 
-        let sol_amount_scaled =
-            event.sol_amount as f64 / 10f64.powi(SOL_DECIMALS as i32);
-        let token_amount_scaled =
-            event.token_amount as f64 / 10f64.powi(TOKEN_DECIMALS as i32);
+        let sol_amount_scaled = event.sol_amount as f64 / 10f64.powi(SOL_DECIMALS as i32);
+        let token_amount_scaled = event.token_amount as f64 / 10f64.powi(TOKEN_DECIMALS as i32);
 
         let mut record = SwapRecord::default();
 

--- a/jetstreamer-dex-trades/src/decoders/pump_fun/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/pump_fun/mod.rs
@@ -1,0 +1,87 @@
+mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+
+const PROGRAM_ID: &str = "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P";
+const SOL_MINT: &str = "So11111111111111111111111111111111111111112";
+const SOL_DECIMALS: u8 = 9;
+const TOKEN_DECIMALS: u8 = 6;
+
+pub struct PumpFunDecoder;
+
+impl DexDecoder for PumpFunDecoder {
+    fn name(&self) -> &'static str {
+        "Pump Fun"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        _tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        let accounts = ix.accounts();
+
+        let (event, is_buy) = idl::events::decode_trade_event(data)?;
+
+        let mint = Address::new_from_array(event.mint);
+        let mint_str = mint.to_string();
+        let user = Address::new_from_array(event.user);
+
+        let pool_address = if accounts.len() > 3 {
+            accounts[3].to_string()
+        } else {
+            String::new()
+        };
+
+        let signer = if accounts.len() > 6 {
+            accounts[6].to_string()
+        } else {
+            user.to_string()
+        };
+
+        let sol_amount_scaled =
+            event.sol_amount as f64 / 10f64.powi(SOL_DECIMALS as i32);
+        let token_amount_scaled =
+            event.token_amount as f64 / 10f64.powi(TOKEN_DECIMALS as i32);
+
+        let mut record = SwapRecord::default();
+
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool_address;
+        record.signer = signer;
+
+        if is_buy {
+            record.instruction_type = "Buy".to_string();
+            record.token_bought_mint = mint_str;
+            record.token_bought_amount = token_amount_scaled;
+            record.token_bought_decimals = TOKEN_DECIMALS;
+            record.token_sold_mint = SOL_MINT.to_string();
+            record.token_sold_amount = sol_amount_scaled;
+            record.token_sold_decimals = SOL_DECIMALS;
+        } else {
+            record.instruction_type = "Sell".to_string();
+            record.token_bought_mint = SOL_MINT.to_string();
+            record.token_bought_amount = sol_amount_scaled;
+            record.token_bought_decimals = SOL_DECIMALS;
+            record.token_sold_mint = mint_str;
+            record.token_sold_amount = token_amount_scaled;
+            record.token_sold_decimals = TOKEN_DECIMALS;
+        }
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/raydium_amm_v4/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_amm_v4/mod.rs
@@ -4,7 +4,7 @@ use crate::registry::DexDecoder;
 use crate::token_transfers::{get_swap_amounts, get_token_account_info};
 use crate::transaction_ext::TransactionExt;
 use crate::types::SwapRecord;
-use base64::{engine::general_purpose::STANDARD, Engine};
+use base64::{Engine, engine::general_purpose::STANDARD};
 use byteorder::{LittleEndian, ReadBytesExt};
 use jetstreamer_firehose::firehose::TransactionData;
 use std::collections::HashMap;
@@ -65,6 +65,12 @@ pub struct RaydiumAmmV4Decoder {
     event_cache: RwLock<HashMap<String, HashMap<String, SwapInstructionLog>>>,
 }
 
+impl Default for RaydiumAmmV4Decoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RaydiumAmmV4Decoder {
     pub fn new() -> Self {
         Self {
@@ -101,12 +107,11 @@ impl DexDecoder for RaydiumAmmV4Decoder {
 
         for (position, log_messages) in &log_map {
             for msg in log_messages {
-                if let Some(ray_data) = msg.strip_prefix("ray_log: ") {
-                    if let Ok(bytes) = STANDARD.decode(ray_data) {
-                        if let Some(log) = SwapInstructionLog::deserialize(&bytes) {
-                            events.insert(position.clone(), log);
-                        }
-                    }
+                if let Some(ray_data) = msg.strip_prefix("ray_log: ")
+                    && let Ok(bytes) = STANDARD.decode(ray_data)
+                    && let Some(log) = SwapInstructionLog::deserialize(&bytes)
+                {
+                    events.insert(position.clone(), log);
                 }
             }
         }
@@ -213,16 +218,14 @@ impl RaydiumAmmV4Decoder {
 
                 record.token_sold_mint = vault_a_info.mint.clone();
                 record.token_sold_vault = vault_a.to_string();
-                record.token_sold_amount =
-                    log.amount_in as f64 / 10f64.powi(sold_dec as i32);
+                record.token_sold_amount = log.amount_in as f64 / 10f64.powi(sold_dec as i32);
                 record.token_sold_decimals = sold_dec;
                 record.token_sold_vault_reserve =
                     log.pool_coin as f64 / 10f64.powi(sold_dec as i32);
 
                 record.token_bought_mint = vault_b_info.mint.clone();
                 record.token_bought_vault = vault_b.to_string();
-                record.token_bought_amount =
-                    log.out_amount as f64 / 10f64.powi(bought_dec as i32);
+                record.token_bought_amount = log.out_amount as f64 / 10f64.powi(bought_dec as i32);
                 record.token_bought_decimals = bought_dec;
                 record.token_bought_vault_reserve =
                     log.pool_pc as f64 / 10f64.powi(bought_dec as i32);
@@ -234,16 +237,13 @@ impl RaydiumAmmV4Decoder {
 
                 record.token_sold_mint = vault_b_info.mint.clone();
                 record.token_sold_vault = vault_b.to_string();
-                record.token_sold_amount =
-                    log.amount_in as f64 / 10f64.powi(sold_dec as i32);
+                record.token_sold_amount = log.amount_in as f64 / 10f64.powi(sold_dec as i32);
                 record.token_sold_decimals = sold_dec;
-                record.token_sold_vault_reserve =
-                    log.pool_pc as f64 / 10f64.powi(sold_dec as i32);
+                record.token_sold_vault_reserve = log.pool_pc as f64 / 10f64.powi(sold_dec as i32);
 
                 record.token_bought_mint = vault_a_info.mint.clone();
                 record.token_bought_vault = vault_a.to_string();
-                record.token_bought_amount =
-                    log.out_amount as f64 / 10f64.powi(bought_dec as i32);
+                record.token_bought_amount = log.out_amount as f64 / 10f64.powi(bought_dec as i32);
                 record.token_bought_decimals = bought_dec;
                 record.token_bought_vault_reserve =
                     log.pool_coin as f64 / 10f64.powi(bought_dec as i32);
@@ -266,8 +266,7 @@ impl RaydiumAmmV4Decoder {
         let outer_idx = ix.instruction_index() as usize;
         let inner_idx = ix.inner_instruction_index() as usize;
 
-        let swap =
-            get_swap_amounts(tx, outer_idx, inner_idx, vault_a, vault_b, None, false)?;
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, vault_a, vault_b, None, false)?;
 
         let mut record = SwapRecord::default();
         record.instruction_index = ix.instruction_index();

--- a/jetstreamer-dex-trades/src/decoders/raydium_amm_v4/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_amm_v4/mod.rs
@@ -1,0 +1,293 @@
+use crate::instruction_iter::Instruction;
+use crate::log_parser::LogParser;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use base64::{engine::general_purpose::STANDARD, Engine};
+use byteorder::{LittleEndian, ReadBytesExt};
+use jetstreamer_firehose::firehose::TransactionData;
+use std::collections::HashMap;
+use std::io::Cursor;
+use std::sync::RwLock;
+
+const PROGRAM_ID: &str = "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8";
+
+const SWAP_BASE_IN_DISC: u8 = 9;
+const SWAP_BASE_OUT_DISC: u8 = 11;
+
+/// Decoded `ray_log:` swap event from Raydium AMM V4 program logs.
+#[allow(dead_code)]
+#[derive(Debug, Clone)]
+struct SwapInstructionLog {
+    log_type: u8,
+    amount_in: u64,
+    minimum_out: u64,
+    direction: u64,
+    user_source: u64,
+    pool_coin: u64,
+    pool_pc: u64,
+    out_amount: u64,
+}
+
+impl SwapInstructionLog {
+    /// Layout: log_type(1) + amount_in(8) + minimum_out(8) + direction(8)
+    ///       + user_source(8) + pool_coin(8) + pool_pc(8) + out_amount(8) = 57 bytes
+    fn deserialize(data: &[u8]) -> Option<Self> {
+        if data.len() < 57 {
+            return None;
+        }
+        let mut cursor = Cursor::new(data);
+        let log_type = cursor.read_u8().ok()?;
+        let amount_in = cursor.read_u64::<LittleEndian>().ok()?;
+        let minimum_out = cursor.read_u64::<LittleEndian>().ok()?;
+        let direction = cursor.read_u64::<LittleEndian>().ok()?;
+        let user_source = cursor.read_u64::<LittleEndian>().ok()?;
+        let pool_coin = cursor.read_u64::<LittleEndian>().ok()?;
+        let pool_pc = cursor.read_u64::<LittleEndian>().ok()?;
+        let out_amount = cursor.read_u64::<LittleEndian>().ok()?;
+
+        Some(Self {
+            log_type,
+            amount_in,
+            minimum_out,
+            direction,
+            user_source,
+            pool_coin,
+            pool_pc,
+            out_amount,
+        })
+    }
+}
+
+pub struct RaydiumAmmV4Decoder {
+    /// tx_id → (position → SwapInstructionLog)
+    event_cache: RwLock<HashMap<String, HashMap<String, SwapInstructionLog>>>,
+}
+
+impl RaydiumAmmV4Decoder {
+    pub fn new() -> Self {
+        Self {
+            event_cache: RwLock::new(HashMap::new()),
+        }
+    }
+
+    fn get_position(ix: &Instruction) -> String {
+        match ix {
+            Instruction::TopLevel { index, .. } => index.to_string(),
+            Instruction::Inner {
+                parent_index,
+                index,
+                ..
+            } => format!("{}.{}", parent_index, index),
+        }
+    }
+}
+
+impl DexDecoder for RaydiumAmmV4Decoder {
+    fn name(&self) -> &'static str {
+        "Raydium AMM V4"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn on_transaction_start(&self, tx: &TransactionData) {
+        let logs = tx.get_logs();
+        let log_map = LogParser::extract_program_logs_by_position(&logs, PROGRAM_ID);
+
+        let mut events: HashMap<String, SwapInstructionLog> = HashMap::new();
+
+        for (position, log_messages) in &log_map {
+            for msg in log_messages {
+                if let Some(ray_data) = msg.strip_prefix("ray_log: ") {
+                    if let Ok(bytes) = STANDARD.decode(ray_data) {
+                        if let Some(log) = SwapInstructionLog::deserialize(&bytes) {
+                            events.insert(position.clone(), log);
+                        }
+                    }
+                }
+            }
+        }
+
+        if !events.is_empty() {
+            let tx_id = tx.signature.to_string();
+            let mut cache = self.event_cache.write().unwrap();
+            cache.insert(tx_id, events);
+        }
+    }
+
+    fn on_transaction_end(&self, tx_id: &str) {
+        let mut cache = self.event_cache.write().unwrap();
+        cache.remove(tx_id);
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.is_empty() {
+            return None;
+        }
+
+        let instruction_type = match data[0] {
+            SWAP_BASE_IN_DISC => "SwapBaseIn",
+            SWAP_BASE_OUT_DISC => "SwapBaseOut",
+            _ => return None,
+        };
+
+        let accounts = ix.accounts();
+        if accounts.len() < 6 {
+            return None;
+        }
+
+        let pool = accounts[1].to_string();
+        let vault_a = accounts[4].to_string();
+        let vault_b = accounts[5].to_string();
+
+        let position = Self::get_position(ix);
+        let tx_id = tx.signature.to_string();
+
+        let cache = self.event_cache.read().unwrap();
+        let event = cache.get(&tx_id).and_then(|m| m.get(&position)).cloned();
+        drop(cache);
+
+        if let Some(log) = event {
+            self.decode_from_log(
+                tx,
+                ix,
+                outer_program,
+                instruction_type,
+                &pool,
+                &vault_a,
+                &vault_b,
+                &log,
+            )
+        } else {
+            self.decode_from_transfers(
+                tx,
+                ix,
+                outer_program,
+                instruction_type,
+                &pool,
+                &vault_a,
+                &vault_b,
+            )
+        }
+    }
+}
+
+impl RaydiumAmmV4Decoder {
+    fn decode_from_log(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        instruction_type: &str,
+        pool: &str,
+        vault_a: &str,
+        vault_b: &str,
+        log: &SwapInstructionLog,
+    ) -> Option<SwapRecord> {
+        let vault_a_info = get_token_account_info(tx, vault_a)?;
+        let vault_b_info = get_token_account_info(tx, vault_b)?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool.to_string();
+
+        match log.direction {
+            1 => {
+                // User sells coin (token_a via vault_a), buys pc (token_b via vault_b)
+                let sold_dec = vault_a_info.decimals;
+                let bought_dec = vault_b_info.decimals;
+
+                record.token_sold_mint = vault_a_info.mint.clone();
+                record.token_sold_vault = vault_a.to_string();
+                record.token_sold_amount =
+                    log.amount_in as f64 / 10f64.powi(sold_dec as i32);
+                record.token_sold_decimals = sold_dec;
+                record.token_sold_vault_reserve =
+                    log.pool_coin as f64 / 10f64.powi(sold_dec as i32);
+
+                record.token_bought_mint = vault_b_info.mint.clone();
+                record.token_bought_vault = vault_b.to_string();
+                record.token_bought_amount =
+                    log.out_amount as f64 / 10f64.powi(bought_dec as i32);
+                record.token_bought_decimals = bought_dec;
+                record.token_bought_vault_reserve =
+                    log.pool_pc as f64 / 10f64.powi(bought_dec as i32);
+            }
+            _ => {
+                // direction == 2: User sells pc (token_b via vault_b), buys coin (token_a via vault_a)
+                let sold_dec = vault_b_info.decimals;
+                let bought_dec = vault_a_info.decimals;
+
+                record.token_sold_mint = vault_b_info.mint.clone();
+                record.token_sold_vault = vault_b.to_string();
+                record.token_sold_amount =
+                    log.amount_in as f64 / 10f64.powi(sold_dec as i32);
+                record.token_sold_decimals = sold_dec;
+                record.token_sold_vault_reserve =
+                    log.pool_pc as f64 / 10f64.powi(sold_dec as i32);
+
+                record.token_bought_mint = vault_a_info.mint.clone();
+                record.token_bought_vault = vault_a.to_string();
+                record.token_bought_amount =
+                    log.out_amount as f64 / 10f64.powi(bought_dec as i32);
+                record.token_bought_decimals = bought_dec;
+                record.token_bought_vault_reserve =
+                    log.pool_coin as f64 / 10f64.powi(bought_dec as i32);
+            }
+        }
+
+        Some(record)
+    }
+
+    fn decode_from_transfers(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        instruction_type: &str,
+        pool: &str,
+        vault_a: &str,
+        vault_b: &str,
+    ) -> Option<SwapRecord> {
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let swap =
+            get_swap_amounts(tx, outer_idx, inner_idx, vault_a, vault_b, None, false)?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool.to_string();
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/raydium_clmm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_clmm/idl.rs
@@ -1,0 +1,55 @@
+use borsh::BorshDeserialize;
+use solana_address::Address;
+
+pub const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+pub const SWAP_V2_DISC: [u8; 8] = [43, 4, 237, 11, 26, 201, 30, 98];
+
+/// Anchor self-CPI event wrapper discriminator.
+pub const EVENT_WRAPPER_DISC: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+
+/// SwapEvent discriminator emitted via `Program data:` logs.
+pub const SWAP_EVENT_DISC: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
+
+#[derive(Debug, Clone, BorshDeserialize)]
+pub struct SwapEvent {
+    pub pool_state: [u8; 32],
+    pub sender: [u8; 32],
+    pub token_account_0: [u8; 32],
+    pub token_account_1: [u8; 32],
+    pub amount_0: u64,
+    pub transfer_fee_0: u64,
+    pub amount_1: u64,
+    pub transfer_fee_1: u64,
+    pub zero_for_one: bool,
+    pub sqrt_price_x64: u128,
+    pub liquidity: u128,
+    pub tick: i32,
+}
+
+impl SwapEvent {
+    pub fn pool_state_str(&self) -> String {
+        Address::new_from_array(self.pool_state).to_string()
+    }
+
+    pub fn token_account_0_str(&self) -> String {
+        Address::new_from_array(self.token_account_0).to_string()
+    }
+
+    pub fn token_account_1_str(&self) -> String {
+        Address::new_from_array(self.token_account_1).to_string()
+    }
+}
+
+pub mod events {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine};
+
+    /// Decode a SwapEvent from a base64-encoded `Program data:` log entry.
+    pub fn decode_swap_event_from_log(data: &str) -> Option<SwapEvent> {
+        let bytes = STANDARD.decode(data).ok()?;
+        if bytes.len() < 8 || bytes[..8] != SWAP_EVENT_DISC {
+            return None;
+        }
+        SwapEvent::try_from_slice(&bytes[8..]).ok()
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/raydium_clmm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_clmm/idl.rs
@@ -42,7 +42,7 @@ impl SwapEvent {
 
 pub mod events {
     use super::*;
-    use base64::{engine::general_purpose::STANDARD, Engine};
+    use base64::{Engine, engine::general_purpose::STANDARD};
 
     /// Decode a SwapEvent from a base64-encoded `Program data:` log entry.
     pub fn decode_swap_event_from_log(data: &str) -> Option<SwapEvent> {

--- a/jetstreamer-dex-trades/src/decoders/raydium_clmm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_clmm/mod.rs
@@ -1,0 +1,227 @@
+pub mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::log_parser::LogParser;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+use std::collections::{HashMap, VecDeque};
+use std::sync::RwLock;
+
+const PROGRAM_ID: &str = "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK";
+
+const POOL_ACCOUNT_IDX: usize = 2;
+const INPUT_VAULT_IDX: usize = 5;
+const OUTPUT_VAULT_IDX: usize = 6;
+const MIN_ACCOUNTS: usize = 7;
+
+struct EventCache {
+    events: VecDeque<idl::SwapEvent>,
+}
+
+pub struct RaydiumClmmDecoder {
+    cache: RwLock<HashMap<String, EventCache>>,
+}
+
+impl RaydiumClmmDecoder {
+    pub fn new() -> Self {
+        Self {
+            cache: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl DexDecoder for RaydiumClmmDecoder {
+    fn name(&self) -> &'static str {
+        "Raydium CLMM"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn on_transaction_start(&self, tx: &TransactionData) {
+        let logs = tx.get_logs();
+        let data_by_pos = LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
+
+        let mut sorted: Vec<(String, String)> = Vec::new();
+        for (pos, entries) in &data_by_pos {
+            for entry in entries {
+                sorted.push((pos.clone(), entry.clone()));
+            }
+        }
+        sorted.sort_by(|a, b| parse_position(&a.0).cmp(&parse_position(&b.0)));
+
+        let mut events = VecDeque::new();
+        for (_pos, data) in sorted {
+            if let Some(event) = idl::events::decode_swap_event_from_log(&data) {
+                events.push_back(event);
+            }
+        }
+
+        let tx_id = tx.signature.to_string();
+        let mut cache = self.cache.write().unwrap();
+        cache.insert(tx_id, EventCache { events });
+    }
+
+    fn on_transaction_end(&self, tx_id: &str) {
+        let mut cache = self.cache.write().unwrap();
+        cache.remove(tx_id);
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 {
+            return None;
+        }
+
+        let disc = &data[..8];
+        let instruction_type = if disc == idl::SWAP_DISC {
+            "Swap"
+        } else if disc == idl::SWAP_V2_DISC {
+            "SwapV2"
+        } else {
+            return None;
+        };
+
+        let accounts = ix.accounts();
+        if accounts.len() < MIN_ACCOUNTS {
+            return None;
+        }
+
+        let tx_id = tx.signature.to_string();
+        let mut cache = self.cache.write().unwrap();
+        let event = cache
+            .get_mut(&tx_id)
+            .and_then(|e| e.events.pop_front());
+        drop(cache);
+
+        if let Some(event) = event {
+            self.decode_from_event(tx, ix, outer_program, instruction_type, &event)
+        } else {
+            self.decode_from_transfers(tx, ix, outer_program, instruction_type, accounts)
+        }
+    }
+}
+
+impl RaydiumClmmDecoder {
+    fn decode_from_event(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        instruction_type: &str,
+        event: &idl::SwapEvent,
+    ) -> Option<SwapRecord> {
+        let pool = event.pool_state_str();
+        let vault_0 = event.token_account_0_str();
+        let vault_1 = event.token_account_1_str();
+
+        let info_0 = get_token_account_info(tx, &vault_0)?;
+        let info_1 = get_token_account_info(tx, &vault_1)?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        record.sqrt_price = event.sqrt_price_x64.to_string();
+        record.is_base_to_quote = Some(event.zero_for_one);
+
+        if event.zero_for_one {
+            // Selling token_0 → buying token_1
+            record.token_sold_mint = info_0.mint.clone();
+            record.token_sold_vault = vault_0;
+            record.token_sold_amount =
+                event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
+            record.token_sold_decimals = info_0.decimals;
+
+            record.token_bought_mint = info_1.mint.clone();
+            record.token_bought_vault = vault_1;
+            record.token_bought_amount =
+                event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
+            record.token_bought_decimals = info_1.decimals;
+        } else {
+            // Selling token_1 → buying token_0
+            record.token_sold_mint = info_1.mint.clone();
+            record.token_sold_vault = vault_1;
+            record.token_sold_amount =
+                event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
+            record.token_sold_decimals = info_1.decimals;
+
+            record.token_bought_mint = info_0.mint.clone();
+            record.token_bought_vault = vault_0;
+            record.token_bought_amount =
+                event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
+            record.token_bought_decimals = info_0.decimals;
+        }
+
+        Some(record)
+    }
+
+    fn decode_from_transfers(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        instruction_type: &str,
+        accounts: &[Address],
+    ) -> Option<SwapRecord> {
+        let pool = accounts[POOL_ACCOUNT_IDX].to_string();
+        let vault_a = accounts[INPUT_VAULT_IDX].to_string();
+        let vault_b = accounts[OUTPUT_VAULT_IDX].to_string();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let swap = get_swap_amounts(
+            tx,
+            outer_idx,
+            inner_idx,
+            &vault_a,
+            &vault_b,
+            None,
+            false,
+        )?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+
+        Some(record)
+    }
+}
+
+fn parse_position(pos: &str) -> (usize, usize) {
+    let mut parts = pos.split('.');
+    let outer = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let inner = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (outer, inner)
+}

--- a/jetstreamer-dex-trades/src/decoders/raydium_clmm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_clmm/mod.rs
@@ -26,6 +26,12 @@ pub struct RaydiumClmmDecoder {
     cache: RwLock<HashMap<String, EventCache>>,
 }
 
+impl Default for RaydiumClmmDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RaydiumClmmDecoder {
     pub fn new() -> Self {
         Self {
@@ -99,9 +105,7 @@ impl DexDecoder for RaydiumClmmDecoder {
 
         let tx_id = tx.signature.to_string();
         let mut cache = self.cache.write().unwrap();
-        let event = cache
-            .get_mut(&tx_id)
-            .and_then(|e| e.events.pop_front());
+        let event = cache.get_mut(&tx_id).and_then(|e| e.events.pop_front());
         drop(cache);
 
         if let Some(event) = event {
@@ -144,27 +148,23 @@ impl RaydiumClmmDecoder {
             // Selling token_0 → buying token_1
             record.token_sold_mint = info_0.mint.clone();
             record.token_sold_vault = vault_0;
-            record.token_sold_amount =
-                event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
+            record.token_sold_amount = event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
             record.token_sold_decimals = info_0.decimals;
 
             record.token_bought_mint = info_1.mint.clone();
             record.token_bought_vault = vault_1;
-            record.token_bought_amount =
-                event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
+            record.token_bought_amount = event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
             record.token_bought_decimals = info_1.decimals;
         } else {
             // Selling token_1 → buying token_0
             record.token_sold_mint = info_1.mint.clone();
             record.token_sold_vault = vault_1;
-            record.token_sold_amount =
-                event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
+            record.token_sold_amount = event.amount_1 as f64 / 10f64.powi(info_1.decimals as i32);
             record.token_sold_decimals = info_1.decimals;
 
             record.token_bought_mint = info_0.mint.clone();
             record.token_bought_vault = vault_0;
-            record.token_bought_amount =
-                event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
+            record.token_bought_amount = event.amount_0 as f64 / 10f64.powi(info_0.decimals as i32);
             record.token_bought_decimals = info_0.decimals;
         }
 
@@ -186,15 +186,7 @@ impl RaydiumClmmDecoder {
         let outer_idx = ix.instruction_index() as usize;
         let inner_idx = ix.inner_instruction_index() as usize;
 
-        let swap = get_swap_amounts(
-            tx,
-            outer_idx,
-            inner_idx,
-            &vault_a,
-            &vault_b,
-            None,
-            false,
-        )?;
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
 
         let mut record = SwapRecord::default();
         record.instruction_index = ix.instruction_index();

--- a/jetstreamer-dex-trades/src/decoders/raydium_cpmm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_cpmm/idl.rs
@@ -25,7 +25,7 @@ pub struct SwapEvent {
 
 pub mod events {
     use super::*;
-    use base64::{engine::general_purpose::STANDARD, Engine};
+    use base64::{Engine, engine::general_purpose::STANDARD};
 
     /// Decode a SwapEvent from a base64-encoded `Program data:` log entry.
     /// The decoded bytes start with the SwapEvent discriminator (8 bytes)

--- a/jetstreamer-dex-trades/src/decoders/raydium_cpmm/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_cpmm/idl.rs
@@ -1,0 +1,40 @@
+use borsh::BorshDeserialize;
+
+pub const SWAP_BASE_INPUT_DISC: [u8; 8] = [143, 190, 90, 218, 196, 30, 51, 174];
+pub const SWAP_BASE_OUTPUT_DISC: [u8; 8] = [55, 217, 98, 86, 163, 74, 180, 173];
+
+/// Anchor self-CPI event wrapper discriminator (sha256("anchor:event")[..8]).
+pub const EVENT_WRAPPER_DISC: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+
+/// SwapEvent discriminator emitted via `Program data:` logs.
+pub const SWAP_EVENT_DISC: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
+
+#[derive(Debug, Clone, BorshDeserialize)]
+pub struct SwapEvent {
+    pub pool_id: [u8; 32],
+    pub input_vault_before: u64,
+    pub input_vault_after: u64,
+    pub output_vault_before: u64,
+    pub output_vault_after: u64,
+    pub input_amount: u64,
+    pub output_amount: u64,
+    pub input_transfer_fee: u64,
+    pub output_transfer_fee: u64,
+    pub base_input: bool,
+}
+
+pub mod events {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine};
+
+    /// Decode a SwapEvent from a base64-encoded `Program data:` log entry.
+    /// The decoded bytes start with the SwapEvent discriminator (8 bytes)
+    /// followed by the borsh-serialized event payload.
+    pub fn decode_swap_event_from_log(data: &str) -> Option<SwapEvent> {
+        let bytes = STANDARD.decode(data).ok()?;
+        if bytes.len() < 8 || bytes[..8] != SWAP_EVENT_DISC {
+            return None;
+        }
+        SwapEvent::try_from_slice(&bytes[8..]).ok()
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/raydium_cpmm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_cpmm/mod.rs
@@ -1,0 +1,214 @@
+pub mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::log_parser::LogParser;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+use std::collections::{HashMap, VecDeque};
+use std::sync::RwLock;
+
+const PROGRAM_ID: &str = "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C";
+
+const POOL_ACCOUNT_IDX: usize = 3;
+const INPUT_VAULT_IDX: usize = 6;
+const OUTPUT_VAULT_IDX: usize = 7;
+const MIN_ACCOUNTS: usize = 8;
+
+struct EventCache {
+    events: VecDeque<idl::SwapEvent>,
+}
+
+pub struct RaydiumCpmmDecoder {
+    cache: RwLock<HashMap<String, EventCache>>,
+}
+
+impl RaydiumCpmmDecoder {
+    pub fn new() -> Self {
+        Self {
+            cache: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl DexDecoder for RaydiumCpmmDecoder {
+    fn name(&self) -> &'static str {
+        "Raydium CPMM"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn on_transaction_start(&self, tx: &TransactionData) {
+        let logs = tx.get_logs();
+        let data_by_pos = LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
+
+        let mut sorted: Vec<(String, String)> = Vec::new();
+        for (pos, entries) in &data_by_pos {
+            for entry in entries {
+                sorted.push((pos.clone(), entry.clone()));
+            }
+        }
+        sorted.sort_by(|a, b| parse_position(&a.0).cmp(&parse_position(&b.0)));
+
+        let mut events = VecDeque::new();
+        for (_pos, data) in sorted {
+            if let Some(event) = idl::events::decode_swap_event_from_log(&data) {
+                events.push_back(event);
+            }
+        }
+
+        let tx_id = tx.signature.to_string();
+        let mut cache = self.cache.write().unwrap();
+        cache.insert(tx_id, EventCache { events });
+    }
+
+    fn on_transaction_end(&self, tx_id: &str) {
+        let mut cache = self.cache.write().unwrap();
+        cache.remove(tx_id);
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 {
+            return None;
+        }
+
+        let disc = &data[..8];
+        let instruction_type = if disc == idl::SWAP_BASE_INPUT_DISC {
+            "SwapBaseInput"
+        } else if disc == idl::SWAP_BASE_OUTPUT_DISC {
+            "SwapBaseOutput"
+        } else {
+            return None;
+        };
+
+        let accounts = ix.accounts();
+        if accounts.len() < MIN_ACCOUNTS {
+            return None;
+        }
+
+        let tx_id = tx.signature.to_string();
+        let mut cache = self.cache.write().unwrap();
+        let event = cache
+            .get_mut(&tx_id)
+            .and_then(|e| e.events.pop_front());
+        drop(cache);
+
+        if let Some(event) = event {
+            self.decode_from_event(tx, ix, outer_program, instruction_type, &event, accounts)
+        } else {
+            self.decode_from_transfers(tx, ix, outer_program, instruction_type, accounts)
+        }
+    }
+}
+
+impl RaydiumCpmmDecoder {
+    fn decode_from_event(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        instruction_type: &str,
+        event: &idl::SwapEvent,
+        accounts: &[Address],
+    ) -> Option<SwapRecord> {
+        let pool = Address::new_from_array(event.pool_id).to_string();
+        let input_vault_addr = accounts[INPUT_VAULT_IDX].to_string();
+        let output_vault_addr = accounts[OUTPUT_VAULT_IDX].to_string();
+
+        let input_info = get_token_account_info(tx, &input_vault_addr)?;
+        let output_info = get_token_account_info(tx, &output_vault_addr)?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        let in_dec = input_info.decimals;
+        let out_dec = output_info.decimals;
+
+        record.token_sold_mint = input_info.mint.clone();
+        record.token_sold_vault = input_vault_addr;
+        record.token_sold_amount = event.input_amount as f64 / 10f64.powi(in_dec as i32);
+        record.token_sold_decimals = in_dec;
+        record.token_sold_vault_reserve =
+            event.input_vault_after as f64 / 10f64.powi(in_dec as i32);
+
+        record.token_bought_mint = output_info.mint.clone();
+        record.token_bought_vault = output_vault_addr;
+        record.token_bought_amount = event.output_amount as f64 / 10f64.powi(out_dec as i32);
+        record.token_bought_decimals = out_dec;
+        record.token_bought_vault_reserve =
+            event.output_vault_after as f64 / 10f64.powi(out_dec as i32);
+
+        Some(record)
+    }
+
+    fn decode_from_transfers(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        instruction_type: &str,
+        accounts: &[Address],
+    ) -> Option<SwapRecord> {
+        let pool = accounts[POOL_ACCOUNT_IDX].to_string();
+        let input_vault = accounts[INPUT_VAULT_IDX].to_string();
+        let output_vault = accounts[OUTPUT_VAULT_IDX].to_string();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let swap = get_swap_amounts(
+            tx,
+            outer_idx,
+            inner_idx,
+            &input_vault,
+            &output_vault,
+            None,
+            false,
+        )?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+
+        Some(record)
+    }
+}
+
+fn parse_position(pos: &str) -> (usize, usize) {
+    let mut parts = pos.split('.');
+    let outer = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let inner = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (outer, inner)
+}

--- a/jetstreamer-dex-trades/src/decoders/raydium_cpmm/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_cpmm/mod.rs
@@ -26,6 +26,12 @@ pub struct RaydiumCpmmDecoder {
     cache: RwLock<HashMap<String, EventCache>>,
 }
 
+impl Default for RaydiumCpmmDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RaydiumCpmmDecoder {
     pub fn new() -> Self {
         Self {
@@ -99,9 +105,7 @@ impl DexDecoder for RaydiumCpmmDecoder {
 
         let tx_id = tx.signature.to_string();
         let mut cache = self.cache.write().unwrap();
-        let event = cache
-            .get_mut(&tx_id)
-            .and_then(|e| e.events.pop_front());
+        let event = cache.get_mut(&tx_id).and_then(|e| e.events.pop_front());
         drop(cache);
 
         if let Some(event) = event {

--- a/jetstreamer-dex-trades/src/decoders/raydium_launchlab/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_launchlab/idl.rs
@@ -1,0 +1,43 @@
+use borsh::BorshDeserialize;
+
+pub const BUY_EXACT_IN_DISC: [u8; 8] = [250, 234, 13, 123, 213, 156, 92, 253];
+pub const SELL_EXACT_IN_DISC: [u8; 8] = [149, 39, 222, 155, 211, 124, 152, 26];
+
+/// Anchor self-CPI event wrapper discriminator.
+pub const EVENT_WRAPPER_DISC: [u8; 8] = [228, 69, 165, 46, 81, 203, 154, 29];
+
+/// SwapEvent discriminator emitted via `Program data:` logs.
+pub const SWAP_EVENT_DISC: [u8; 8] = [64, 198, 205, 232, 38, 8, 113, 226];
+
+#[derive(Debug, Clone, BorshDeserialize)]
+pub struct SwapEvent {
+    pub pool_state: [u8; 32],
+    pub input_vault_before: u64,
+    pub input_vault_after: u64,
+    pub output_vault_before: u64,
+    pub output_vault_after: u64,
+    pub input_amount: u64,
+    pub input_transfer_fee: u64,
+    pub output_amount: u64,
+    pub output_transfer_fee: u64,
+    pub base_input: bool,
+    pub base_reserve: u64,
+    pub quote_reserve: u64,
+    pub quote_protocol_fee: u64,
+    pub platform_fee: u64,
+    pub share_fee: u64,
+}
+
+pub mod events {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine};
+
+    /// Decode a SwapEvent from a base64-encoded `Program data:` log entry.
+    pub fn decode_swap_event_from_log(data: &str) -> Option<SwapEvent> {
+        let bytes = STANDARD.decode(data).ok()?;
+        if bytes.len() < 8 || bytes[..8] != SWAP_EVENT_DISC {
+            return None;
+        }
+        SwapEvent::try_from_slice(&bytes[8..]).ok()
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/raydium_launchlab/idl.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_launchlab/idl.rs
@@ -30,7 +30,7 @@ pub struct SwapEvent {
 
 pub mod events {
     use super::*;
-    use base64::{engine::general_purpose::STANDARD, Engine};
+    use base64::{Engine, engine::general_purpose::STANDARD};
 
     /// Decode a SwapEvent from a base64-encoded `Program data:` log entry.
     pub fn decode_swap_event_from_log(data: &str) -> Option<SwapEvent> {

--- a/jetstreamer-dex-trades/src/decoders/raydium_launchlab/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_launchlab/mod.rs
@@ -1,0 +1,241 @@
+pub mod idl;
+
+use crate::instruction_iter::Instruction;
+use crate::log_parser::LogParser;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+use std::collections::{HashMap, VecDeque};
+use std::sync::RwLock;
+
+const PROGRAM_ID: &str = "LanMV9sAd7wArD4vJFi2qDdfnVhFxYSUg6eADduJ3uj";
+
+const POOL_ACCOUNT_IDX: usize = 4;
+const BASE_VAULT_IDX: usize = 7;
+const QUOTE_VAULT_IDX: usize = 8;
+const MIN_ACCOUNTS: usize = 9;
+
+struct EventCache {
+    events: VecDeque<idl::SwapEvent>,
+}
+
+pub struct RaydiumLaunchLabDecoder {
+    cache: RwLock<HashMap<String, EventCache>>,
+}
+
+impl RaydiumLaunchLabDecoder {
+    pub fn new() -> Self {
+        Self {
+            cache: RwLock::new(HashMap::new()),
+        }
+    }
+}
+
+impl DexDecoder for RaydiumLaunchLabDecoder {
+    fn name(&self) -> &'static str {
+        "Raydium LaunchLab"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn on_transaction_start(&self, tx: &TransactionData) {
+        let logs = tx.get_logs();
+        let data_by_pos = LogParser::extract_program_data_by_position(&logs, PROGRAM_ID);
+
+        let mut sorted: Vec<(String, String)> = Vec::new();
+        for (pos, entries) in &data_by_pos {
+            for entry in entries {
+                sorted.push((pos.clone(), entry.clone()));
+            }
+        }
+        sorted.sort_by(|a, b| parse_position(&a.0).cmp(&parse_position(&b.0)));
+
+        let mut events = VecDeque::new();
+        for (_pos, data) in sorted {
+            if let Some(event) = idl::events::decode_swap_event_from_log(&data) {
+                events.push_back(event);
+            }
+        }
+
+        let tx_id = tx.signature.to_string();
+        let mut cache = self.cache.write().unwrap();
+        cache.insert(tx_id, EventCache { events });
+    }
+
+    fn on_transaction_end(&self, tx_id: &str) {
+        let mut cache = self.cache.write().unwrap();
+        cache.remove(tx_id);
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 {
+            return None;
+        }
+
+        let disc = &data[..8];
+        let instruction_type = if disc == idl::BUY_EXACT_IN_DISC {
+            "BuyExactIn"
+        } else if disc == idl::SELL_EXACT_IN_DISC {
+            "SellExactIn"
+        } else {
+            return None;
+        };
+
+        let accounts = ix.accounts();
+        if accounts.len() < MIN_ACCOUNTS {
+            return None;
+        }
+
+        let tx_id = tx.signature.to_string();
+        let mut cache = self.cache.write().unwrap();
+        let event = cache
+            .get_mut(&tx_id)
+            .and_then(|e| e.events.pop_front());
+        drop(cache);
+
+        if let Some(event) = event {
+            self.decode_from_event(tx, ix, outer_program, instruction_type, &event, accounts)
+        } else {
+            self.decode_from_transfers(tx, ix, outer_program, instruction_type, accounts)
+        }
+    }
+}
+
+impl RaydiumLaunchLabDecoder {
+    fn decode_from_event(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        instruction_type: &str,
+        event: &idl::SwapEvent,
+        accounts: &[Address],
+    ) -> Option<SwapRecord> {
+        let pool = Address::new_from_array(event.pool_state).to_string();
+
+        // base_vault and quote_vault from fixed account positions
+        let base_vault_addr = accounts[BASE_VAULT_IDX].to_string();
+        let quote_vault_addr = accounts[QUOTE_VAULT_IDX].to_string();
+
+        let base_info = get_token_account_info(tx, &base_vault_addr)?;
+        let quote_info = get_token_account_info(tx, &quote_vault_addr)?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        if event.base_input {
+            // Selling base → buying quote
+            let in_dec = base_info.decimals;
+            let out_dec = quote_info.decimals;
+
+            record.token_sold_mint = base_info.mint.clone();
+            record.token_sold_vault = base_vault_addr;
+            record.token_sold_amount =
+                event.input_amount as f64 / 10f64.powi(in_dec as i32);
+            record.token_sold_decimals = in_dec;
+            record.token_sold_vault_reserve =
+                event.input_vault_after as f64 / 10f64.powi(in_dec as i32);
+
+            record.token_bought_mint = quote_info.mint.clone();
+            record.token_bought_vault = quote_vault_addr;
+            record.token_bought_amount =
+                event.output_amount as f64 / 10f64.powi(out_dec as i32);
+            record.token_bought_decimals = out_dec;
+            record.token_bought_vault_reserve =
+                event.output_vault_after as f64 / 10f64.powi(out_dec as i32);
+        } else {
+            // Selling quote → buying base
+            let in_dec = quote_info.decimals;
+            let out_dec = base_info.decimals;
+
+            record.token_sold_mint = quote_info.mint.clone();
+            record.token_sold_vault = quote_vault_addr;
+            record.token_sold_amount =
+                event.input_amount as f64 / 10f64.powi(in_dec as i32);
+            record.token_sold_decimals = in_dec;
+            record.token_sold_vault_reserve =
+                event.input_vault_after as f64 / 10f64.powi(in_dec as i32);
+
+            record.token_bought_mint = base_info.mint.clone();
+            record.token_bought_vault = base_vault_addr;
+            record.token_bought_amount =
+                event.output_amount as f64 / 10f64.powi(out_dec as i32);
+            record.token_bought_decimals = out_dec;
+            record.token_bought_vault_reserve =
+                event.output_vault_after as f64 / 10f64.powi(out_dec as i32);
+        }
+
+        Some(record)
+    }
+
+    fn decode_from_transfers(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+        instruction_type: &str,
+        accounts: &[Address],
+    ) -> Option<SwapRecord> {
+        let pool = accounts[POOL_ACCOUNT_IDX].to_string();
+        let base_vault = accounts[BASE_VAULT_IDX].to_string();
+        let quote_vault = accounts[QUOTE_VAULT_IDX].to_string();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let swap = get_swap_amounts(
+            tx,
+            outer_idx,
+            inner_idx,
+            &base_vault,
+            &quote_vault,
+            None,
+            false,
+        )?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+
+        Some(record)
+    }
+}
+
+fn parse_position(pos: &str) -> (usize, usize) {
+    let mut parts = pos.split('.');
+    let outer = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    let inner = parts.next().and_then(|s| s.parse().ok()).unwrap_or(0);
+    (outer, inner)
+}

--- a/jetstreamer-dex-trades/src/decoders/raydium_launchlab/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/raydium_launchlab/mod.rs
@@ -26,6 +26,12 @@ pub struct RaydiumLaunchLabDecoder {
     cache: RwLock<HashMap<String, EventCache>>,
 }
 
+impl Default for RaydiumLaunchLabDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RaydiumLaunchLabDecoder {
     pub fn new() -> Self {
         Self {
@@ -99,9 +105,7 @@ impl DexDecoder for RaydiumLaunchLabDecoder {
 
         let tx_id = tx.signature.to_string();
         let mut cache = self.cache.write().unwrap();
-        let event = cache
-            .get_mut(&tx_id)
-            .and_then(|e| e.events.pop_front());
+        let event = cache.get_mut(&tx_id).and_then(|e| e.events.pop_front());
         drop(cache);
 
         if let Some(event) = event {
@@ -147,16 +151,14 @@ impl RaydiumLaunchLabDecoder {
 
             record.token_sold_mint = base_info.mint.clone();
             record.token_sold_vault = base_vault_addr;
-            record.token_sold_amount =
-                event.input_amount as f64 / 10f64.powi(in_dec as i32);
+            record.token_sold_amount = event.input_amount as f64 / 10f64.powi(in_dec as i32);
             record.token_sold_decimals = in_dec;
             record.token_sold_vault_reserve =
                 event.input_vault_after as f64 / 10f64.powi(in_dec as i32);
 
             record.token_bought_mint = quote_info.mint.clone();
             record.token_bought_vault = quote_vault_addr;
-            record.token_bought_amount =
-                event.output_amount as f64 / 10f64.powi(out_dec as i32);
+            record.token_bought_amount = event.output_amount as f64 / 10f64.powi(out_dec as i32);
             record.token_bought_decimals = out_dec;
             record.token_bought_vault_reserve =
                 event.output_vault_after as f64 / 10f64.powi(out_dec as i32);
@@ -167,16 +169,14 @@ impl RaydiumLaunchLabDecoder {
 
             record.token_sold_mint = quote_info.mint.clone();
             record.token_sold_vault = quote_vault_addr;
-            record.token_sold_amount =
-                event.input_amount as f64 / 10f64.powi(in_dec as i32);
+            record.token_sold_amount = event.input_amount as f64 / 10f64.powi(in_dec as i32);
             record.token_sold_decimals = in_dec;
             record.token_sold_vault_reserve =
                 event.input_vault_after as f64 / 10f64.powi(in_dec as i32);
 
             record.token_bought_mint = base_info.mint.clone();
             record.token_bought_vault = base_vault_addr;
-            record.token_bought_amount =
-                event.output_amount as f64 / 10f64.powi(out_dec as i32);
+            record.token_bought_amount = event.output_amount as f64 / 10f64.powi(out_dec as i32);
             record.token_bought_decimals = out_dec;
             record.token_bought_vault_reserve =
                 event.output_vault_after as f64 / 10f64.powi(out_dec as i32);

--- a/jetstreamer-dex-trades/src/decoders/solfi_v1/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/solfi_v1/mod.rs
@@ -1,0 +1,88 @@
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "SoLFiHG9TfgtdUXUjWAxi3LtvYuFyDLVhBWxdMZxyCe";
+const SWAP_DISC: u8 = 7;
+
+pub struct SolfiV1Decoder;
+
+impl SolfiV1Decoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SolfiV1Decoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for SolfiV1Decoder {
+    fn name(&self) -> &'static str {
+        "SolFi V1"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.is_empty() || data[0] != SWAP_DISC {
+            return None;
+        }
+
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+        let pool = accounts.get(1).cloned().unwrap_or_default();
+        let vault_a = accounts.get(2).cloned().unwrap_or_default();
+        let vault_b = accounts.get(3).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
+
+        let vault_a_info = get_token_account_info(tx, &vault_a);
+        let vault_b_info = get_token_account_info(tx, &vault_b);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+        record.instruction_type = "Swap".to_string();
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+
+        record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+        record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/solfi_v1/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/solfi_v1/mod.rs
@@ -73,14 +73,26 @@ impl DexDecoder for SolfiV1Decoder {
         record.token_bought_decimals = swap.bought.decimals;
 
         record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
         record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
 
         Some(record)

--- a/jetstreamer-dex-trades/src/decoders/solfi_v2/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/solfi_v2/mod.rs
@@ -1,0 +1,88 @@
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "SV2EYYJyRz2YhfXwXnhNAevDEui5Q6yrfyo13WtupPF";
+const SWAP_DISC: u8 = 7;
+
+pub struct SolfiV2Decoder;
+
+impl SolfiV2Decoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for SolfiV2Decoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for SolfiV2Decoder {
+    fn name(&self) -> &'static str {
+        "SolFi V2"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.is_empty() || data[0] != SWAP_DISC {
+            return None;
+        }
+
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+        let pool = accounts.get(1).cloned().unwrap_or_default();
+        let vault_a = accounts.get(4).cloned().unwrap_or_default();
+        let vault_b = accounts.get(5).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
+
+        let vault_a_info = get_token_account_info(tx, &vault_a);
+        let vault_b_info = get_token_account_info(tx, &vault_b);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+        record.instruction_type = "Swap".to_string();
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+
+        record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+        record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/solfi_v2/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/solfi_v2/mod.rs
@@ -73,14 +73,26 @@ impl DexDecoder for SolfiV2Decoder {
         record.token_bought_decimals = swap.bought.decimals;
 
         record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
         record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
 
         Some(record)

--- a/jetstreamer-dex-trades/src/decoders/stabble_stable/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/stabble_stable/mod.rs
@@ -1,0 +1,100 @@
+use crate::instruction_iter::Instruction;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use crate::registry::DexDecoder;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "swapNyd8XiQwJ6ianp9snpu4brUqFxadzvHebnAXjJZ";
+
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+const SWAP_V2_DISC: [u8; 8] = [43, 4, 237, 11, 26, 201, 30, 98];
+
+pub struct StabbleStableDecoder;
+
+impl DexDecoder for StabbleStableDecoder {
+    fn name(&self) -> &'static str {
+        "Stabble Stable"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let accounts = ix.accounts();
+
+        let (instruction_type, pool, vault_a, vault_b, fee_account) =
+            if ix.has_discriminator(&SWAP_DISC) {
+                if accounts.len() < 7 {
+                    return None;
+                }
+                (
+                    "Swap",
+                    accounts[6].to_string(),
+                    accounts[3].to_string(),
+                    accounts[4].to_string(),
+                    accounts[5].to_string(),
+                )
+            } else if ix.has_discriminator(&SWAP_V2_DISC) {
+                if accounts.len() < 9 {
+                    return None;
+                }
+                (
+                    "SwapV2",
+                    accounts[8].to_string(),
+                    accounts[5].to_string(),
+                    accounts[6].to_string(),
+                    accounts[7].to_string(),
+                )
+            } else {
+                return None;
+            };
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let exclude = [fee_account.as_str()];
+        let amounts = get_swap_amounts(
+            tx,
+            outer_idx,
+            inner_idx,
+            &vault_a,
+            &vault_b,
+            Some(&exclude),
+            true,
+        )?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        record.token_sold_mint = amounts.sold.mint.clone();
+        record.token_sold_vault = amounts.sold.vault.clone();
+        record.token_sold_amount = amounts.sold.amount_scaled();
+        record.token_sold_decimals = amounts.sold.decimals;
+
+        record.token_bought_mint = amounts.bought.mint.clone();
+        record.token_bought_vault = amounts.bought.vault.clone();
+        record.token_bought_amount = amounts.bought.amount_scaled();
+        record.token_bought_decimals = amounts.bought.decimals;
+
+        let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
+        let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
+        record.token_sold_vault_reserve =
+            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_bought_vault_reserve =
+            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/stabble_stable/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/stabble_stable/mod.rs
@@ -1,7 +1,7 @@
 use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
 use crate::token_transfers::{get_swap_amounts, get_token_account_info};
 use crate::types::SwapRecord;
-use crate::registry::DexDecoder;
 use jetstreamer_firehose::firehose::TransactionData;
 
 const PROGRAM_ID: &str = "swapNyd8XiQwJ6ianp9snpu4brUqFxadzvHebnAXjJZ";
@@ -90,10 +90,12 @@ impl DexDecoder for StabbleStableDecoder {
 
         let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
         let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
-        record.token_sold_vault_reserve =
-            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
-        record.token_bought_vault_reserve =
-            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_sold_vault_reserve = sold_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        record.token_bought_vault_reserve = bought_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
 
         Some(record)
     }

--- a/jetstreamer-dex-trades/src/decoders/stabble_weighted/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/stabble_weighted/mod.rs
@@ -1,7 +1,7 @@
 use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
 use crate::token_transfers::{get_swap_amounts, get_token_account_info};
 use crate::types::SwapRecord;
-use crate::registry::DexDecoder;
 use jetstreamer_firehose::firehose::TransactionData;
 
 const PROGRAM_ID: &str = "swapFpHZwjELNnjvThjajtiVmkz3yPQEHjLtka2fwHW";
@@ -90,10 +90,12 @@ impl DexDecoder for StabbleWeightedDecoder {
 
         let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
         let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
-        record.token_sold_vault_reserve =
-            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
-        record.token_bought_vault_reserve =
-            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_sold_vault_reserve = sold_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
+        record.token_bought_vault_reserve = bought_vault_info
+            .map(|i| i.post_balance_scaled())
+            .unwrap_or(0.0);
 
         Some(record)
     }

--- a/jetstreamer-dex-trades/src/decoders/stabble_weighted/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/stabble_weighted/mod.rs
@@ -1,0 +1,100 @@
+use crate::instruction_iter::Instruction;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use crate::registry::DexDecoder;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "swapFpHZwjELNnjvThjajtiVmkz3yPQEHjLtka2fwHW";
+
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+const SWAP_V2_DISC: [u8; 8] = [43, 4, 237, 11, 26, 201, 30, 98];
+
+pub struct StabbleWeightedDecoder;
+
+impl DexDecoder for StabbleWeightedDecoder {
+    fn name(&self) -> &'static str {
+        "Stabble Weighted"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let accounts = ix.accounts();
+
+        let (instruction_type, pool, vault_a, vault_b, fee_account) =
+            if ix.has_discriminator(&SWAP_DISC) {
+                if accounts.len() < 7 {
+                    return None;
+                }
+                (
+                    "Swap",
+                    accounts[6].to_string(),
+                    accounts[3].to_string(),
+                    accounts[4].to_string(),
+                    accounts[5].to_string(),
+                )
+            } else if ix.has_discriminator(&SWAP_V2_DISC) {
+                if accounts.len() < 9 {
+                    return None;
+                }
+                (
+                    "SwapV2",
+                    accounts[8].to_string(),
+                    accounts[5].to_string(),
+                    accounts[6].to_string(),
+                    accounts[7].to_string(),
+                )
+            } else {
+                return None;
+            };
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let exclude = [fee_account.as_str()];
+        let amounts = get_swap_amounts(
+            tx,
+            outer_idx,
+            inner_idx,
+            &vault_a,
+            &vault_b,
+            Some(&exclude),
+            true,
+        )?;
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.instruction_type = instruction_type.to_string();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+
+        record.token_sold_mint = amounts.sold.mint.clone();
+        record.token_sold_vault = amounts.sold.vault.clone();
+        record.token_sold_amount = amounts.sold.amount_scaled();
+        record.token_sold_decimals = amounts.sold.decimals;
+
+        record.token_bought_mint = amounts.bought.mint.clone();
+        record.token_bought_vault = amounts.bought.vault.clone();
+        record.token_bought_amount = amounts.bought.amount_scaled();
+        record.token_bought_decimals = amounts.bought.decimals;
+
+        let sold_vault_info = get_token_account_info(tx, &record.token_sold_vault);
+        let bought_vault_info = get_token_account_info(tx, &record.token_bought_vault);
+        record.token_sold_vault_reserve =
+            sold_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+        record.token_bought_vault_reserve =
+            bought_vault_info.map(|i| i.post_balance_scaled()).unwrap_or(0.0);
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/tessera/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/tessera/mod.rs
@@ -73,14 +73,26 @@ impl DexDecoder for TesseraDecoder {
         record.token_bought_decimals = swap.bought.decimals;
 
         record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
         record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
 
         Some(record)

--- a/jetstreamer-dex-trades/src/decoders/tessera/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/tessera/mod.rs
@@ -1,0 +1,88 @@
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "TessVdML9pBGgG9yGks7o4HewRaXVAMuoVj4x83GLQH";
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub struct TesseraDecoder;
+
+impl TesseraDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for TesseraDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for TesseraDecoder {
+    fn name(&self) -> &'static str {
+        "Tessera"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 || data[..8] != SWAP_DISC {
+            return None;
+        }
+
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+        let pool = accounts.first().cloned().unwrap_or_default();
+        let vault_a = accounts.get(3).cloned().unwrap_or_default();
+        let vault_b = accounts.get(4).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
+
+        let vault_a_info = get_token_account_info(tx, &vault_a);
+        let vault_b_info = get_token_account_info(tx, &vault_b);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+        record.instruction_type = "Swap".to_string();
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+
+        record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+        record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/decoders/zerofi/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/zerofi/mod.rs
@@ -73,14 +73,26 @@ impl DexDecoder for ZerofiDecoder {
         record.token_bought_decimals = swap.bought.decimals;
 
         record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
         record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
-            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_a_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         } else {
-            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+            vault_b_info
+                .as_ref()
+                .map(|i| i.post_balance_scaled())
+                .unwrap_or(0.0)
         };
 
         Some(record)

--- a/jetstreamer-dex-trades/src/decoders/zerofi/mod.rs
+++ b/jetstreamer-dex-trades/src/decoders/zerofi/mod.rs
@@ -1,0 +1,88 @@
+use crate::instruction_iter::Instruction;
+use crate::registry::DexDecoder;
+use crate::token_transfers::{get_swap_amounts, get_token_account_info};
+use crate::types::SwapRecord;
+use jetstreamer_firehose::firehose::TransactionData;
+
+const PROGRAM_ID: &str = "ZERor4xhbUycZ6gb9ntrhqscUcZmAbQDjEAtCf4hbZY";
+const SWAP_DISC: [u8; 8] = [248, 198, 158, 145, 225, 117, 135, 200];
+
+pub struct ZerofiDecoder;
+
+impl ZerofiDecoder {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for ZerofiDecoder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexDecoder for ZerofiDecoder {
+    fn name(&self) -> &'static str {
+        "ZeroFi"
+    }
+
+    fn program_ids(&self) -> &[&'static str] {
+        &[PROGRAM_ID]
+    }
+
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord> {
+        let data = ix.data();
+        if data.len() < 8 || data[..8] != SWAP_DISC {
+            return None;
+        }
+
+        let accounts: Vec<String> = ix.accounts().iter().map(|a| a.to_string()).collect();
+        let pool = accounts.first().cloned().unwrap_or_default();
+        let vault_a = accounts.get(3).cloned().unwrap_or_default();
+        let vault_b = accounts.get(4).cloned().unwrap_or_default();
+
+        let outer_idx = ix.instruction_index() as usize;
+        let inner_idx = ix.inner_instruction_index() as usize;
+
+        let swap = get_swap_amounts(tx, outer_idx, inner_idx, &vault_a, &vault_b, None, false)?;
+
+        let vault_a_info = get_token_account_info(tx, &vault_a);
+        let vault_b_info = get_token_account_info(tx, &vault_b);
+
+        let mut record = SwapRecord::default();
+        record.instruction_index = ix.instruction_index();
+        record.inner_instruction_index = ix.inner_instruction_index();
+        record.is_inner_instruction = ix.is_inner();
+        record.outer_program = outer_program.to_string();
+        record.inner_program = PROGRAM_ID.to_string();
+        record.pool_address = pool;
+        record.instruction_type = "Swap".to_string();
+
+        record.token_sold_mint = swap.sold.mint.clone();
+        record.token_sold_vault = swap.sold.vault.clone();
+        record.token_sold_amount = swap.sold.amount_scaled();
+        record.token_sold_decimals = swap.sold.decimals;
+        record.token_bought_mint = swap.bought.mint.clone();
+        record.token_bought_vault = swap.bought.vault.clone();
+        record.token_bought_amount = swap.bought.amount_scaled();
+        record.token_bought_decimals = swap.bought.decimals;
+
+        record.token_sold_vault_reserve = if swap.sold.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+        record.token_bought_vault_reserve = if swap.bought.vault == vault_a {
+            vault_a_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        } else {
+            vault_b_info.as_ref().map(|i| i.post_balance_scaled()).unwrap_or(0.0)
+        };
+
+        Some(record)
+    }
+}

--- a/jetstreamer-dex-trades/src/instruction_iter.rs
+++ b/jetstreamer-dex-trades/src/instruction_iter.rs
@@ -146,7 +146,7 @@ impl Iterator for AllInstructionIter {
 
             if !self.in_inner_mode {
                 let ix = &self.instructions[outer_array_index];
-                let program_id = self.account_keys.get(ix.program_id_index as usize)?.clone();
+                let program_id = *self.account_keys.get(ix.program_id_index as usize)?;
                 let accounts = ix
                     .accounts
                     .iter()
@@ -171,10 +171,9 @@ impl Iterator for AllInstructionIter {
 
                 if inner_array_index < inner_set.instructions.len() {
                     let inner_ix = &inner_set.instructions[inner_array_index];
-                    let program_id = self
+                    let program_id = *self
                         .account_keys
-                        .get(inner_ix.instruction.program_id_index as usize)?
-                        .clone();
+                        .get(inner_ix.instruction.program_id_index as usize)?;
                     let accounts: Vec<Address> = inner_ix
                         .instruction
                         .accounts

--- a/jetstreamer-dex-trades/src/instruction_iter.rs
+++ b/jetstreamer-dex-trades/src/instruction_iter.rs
@@ -1,0 +1,240 @@
+//! Instruction iterators for traversing outer and inner instructions.
+//!
+//! Provides a unified [`Instruction`] enum and extension traits that let
+//! callers iterate over every instruction in a transaction (top-level and
+//! inner/CPI) with resolved account addresses and program IDs.
+
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+use solana_message::VersionedMessage;
+
+#[derive(Debug, Clone)]
+struct CompiledIx {
+    program_id_index: u8,
+    accounts: Vec<u8>,
+    data: Vec<u8>,
+}
+
+/// Unified instruction type (outer or inner).
+#[derive(Debug, Clone)]
+pub enum Instruction {
+    /// A top-level instruction from the transaction message.
+    TopLevel {
+        /// 1-based index within the transaction.
+        index: usize,
+        program_id: Address,
+        accounts: Vec<Address>,
+        data: Vec<u8>,
+    },
+    /// An inner instruction produced by a CPI.
+    Inner {
+        /// 1-based index of the parent outer instruction.
+        parent_index: usize,
+        /// 1-based index within the parent's inner instruction list.
+        index: usize,
+        program_id: Address,
+        accounts: Vec<Address>,
+        data: Vec<u8>,
+        stack_height: Option<u32>,
+    },
+}
+
+impl Instruction {
+    pub fn program_id(&self) -> &Address {
+        match self {
+            Self::TopLevel { program_id, .. } | Self::Inner { program_id, .. } => program_id,
+        }
+    }
+
+    pub fn data(&self) -> &[u8] {
+        match self {
+            Self::TopLevel { data, .. } | Self::Inner { data, .. } => data,
+        }
+    }
+
+    pub fn accounts(&self) -> &[Address] {
+        match self {
+            Self::TopLevel { accounts, .. } | Self::Inner { accounts, .. } => accounts,
+        }
+    }
+
+    pub fn is_inner(&self) -> bool {
+        matches!(self, Self::Inner { .. })
+    }
+
+    pub fn instruction_index(&self) -> u32 {
+        match self {
+            Self::TopLevel { index, .. } => *index as u32,
+            Self::Inner { parent_index, .. } => *parent_index as u32,
+        }
+    }
+
+    pub fn inner_instruction_index(&self) -> u32 {
+        match self {
+            Self::TopLevel { .. } => 0,
+            Self::Inner { index, .. } => *index as u32,
+        }
+    }
+
+    pub fn has_discriminator(&self, disc: &[u8]) -> bool {
+        let data = self.data();
+        data.len() >= disc.len() && &data[..disc.len()] == disc
+    }
+}
+
+/// Extension trait for [`TransactionData`] providing instruction iterators.
+pub trait InstructionIteratorExt {
+    fn all_instructions(&self) -> AllInstructionIter;
+}
+
+impl InstructionIteratorExt for TransactionData {
+    fn all_instructions(&self) -> AllInstructionIter {
+        AllInstructionIter::new(self)
+    }
+}
+
+/// Iterator over all instructions (outer + inner) in execution order.
+pub struct AllInstructionIter {
+    account_keys: Vec<Address>,
+    instructions: Vec<CompiledIx>,
+    inner_instructions: Vec<solana_transaction_status::InnerInstructions>,
+    outer_index: usize,
+    inner_ix_index: usize,
+    in_inner_mode: bool,
+}
+
+impl AllInstructionIter {
+    pub fn new(tx: &TransactionData) -> Self {
+        let account_keys = get_account_keys(tx);
+        let instructions = get_instructions(tx);
+        let inner_instructions = tx
+            .transaction_status_meta
+            .inner_instructions
+            .clone()
+            .unwrap_or_default();
+
+        Self {
+            account_keys,
+            instructions,
+            inner_instructions,
+            outer_index: 1,
+            inner_ix_index: 1,
+            in_inner_mode: false,
+        }
+    }
+
+    fn get_inner_set(
+        &self,
+        outer_array_index: usize,
+    ) -> Option<&solana_transaction_status::InnerInstructions> {
+        self.inner_instructions
+            .iter()
+            .find(|inner_set| inner_set.index as usize == outer_array_index)
+    }
+}
+
+impl Iterator for AllInstructionIter {
+    type Item = Instruction;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let outer_array_index = self.outer_index - 1;
+
+            if outer_array_index >= self.instructions.len() {
+                return None;
+            }
+
+            if !self.in_inner_mode {
+                let ix = &self.instructions[outer_array_index];
+                let program_id = self.account_keys.get(ix.program_id_index as usize)?.clone();
+                let accounts = ix
+                    .accounts
+                    .iter()
+                    .filter_map(|&idx| self.account_keys.get(idx as usize).cloned())
+                    .collect();
+
+                let result = Instruction::TopLevel {
+                    index: self.outer_index,
+                    program_id,
+                    accounts,
+                    data: ix.data.clone(),
+                };
+
+                self.in_inner_mode = true;
+                self.inner_ix_index = 1;
+
+                return Some(result);
+            }
+
+            if let Some(inner_set) = self.get_inner_set(outer_array_index) {
+                let inner_array_index = self.inner_ix_index - 1;
+
+                if inner_array_index < inner_set.instructions.len() {
+                    let inner_ix = &inner_set.instructions[inner_array_index];
+                    let program_id = self
+                        .account_keys
+                        .get(inner_ix.instruction.program_id_index as usize)?
+                        .clone();
+                    let accounts: Vec<Address> = inner_ix
+                        .instruction
+                        .accounts
+                        .iter()
+                        .filter_map(|&idx| self.account_keys.get(idx as usize).cloned())
+                        .collect();
+
+                    let result = Instruction::Inner {
+                        parent_index: self.outer_index,
+                        index: self.inner_ix_index,
+                        program_id,
+                        accounts,
+                        data: inner_ix.instruction.data.clone(),
+                        stack_height: inner_ix.stack_height,
+                    };
+
+                    self.inner_ix_index += 1;
+                    return Some(result);
+                }
+            }
+
+            self.in_inner_mode = false;
+            self.outer_index += 1;
+        }
+    }
+}
+
+fn get_account_keys(tx: &TransactionData) -> Vec<Address> {
+    match &tx.transaction.message {
+        VersionedMessage::Legacy(msg) => msg.account_keys.clone(),
+        VersionedMessage::V0(msg) => {
+            let mut keys = msg.account_keys.clone();
+            let loaded = &tx.transaction_status_meta.loaded_addresses;
+            keys.extend_from_slice(&loaded.writable);
+            keys.extend_from_slice(&loaded.readonly);
+            keys
+        }
+    }
+}
+
+fn get_instructions(tx: &TransactionData) -> Vec<CompiledIx> {
+    let message = &tx.transaction.message;
+    match message {
+        VersionedMessage::Legacy(msg) => msg
+            .instructions
+            .iter()
+            .map(|ix| CompiledIx {
+                program_id_index: ix.program_id_index,
+                accounts: ix.accounts.clone(),
+                data: ix.data.clone(),
+            })
+            .collect(),
+        VersionedMessage::V0(msg) => msg
+            .instructions
+            .iter()
+            .map(|ix| CompiledIx {
+                program_id_index: ix.program_id_index,
+                accounts: ix.accounts.clone(),
+                data: ix.data.clone(),
+            })
+            .collect(),
+    }
+}

--- a/jetstreamer-dex-trades/src/lib.rs
+++ b/jetstreamer-dex-trades/src/lib.rs
@@ -1,0 +1,59 @@
+//! Solana DEX trades decoder plugin for Jetstreamer.
+//!
+//! Decodes swap transactions from 28+ Solana DEX programs into a unified
+//! [`SwapRecord`] protobuf format, suitable for analytics pipelines,
+//! data lakes, and research tooling.
+//!
+//! # Supported DEXes
+//!
+//! Pump Fun, Pump AMM, Raydium (AMM V4, CPMM, CLMM, LaunchLab),
+//! Orca (V2, Whirlpool), Meteora (DAMM V2, DBC, DLMM, Pools), Manifest,
+//! Aquifer, Lifinity (V1/V2), PancakeSwap CLMM, Byreal CLMM, Futarchy AMM,
+//! AlphaQ, BisonFi, ZeroFi, GoonFi, HumidiFi, Tessera, Obric V2,
+//! SolFi (V1/V2), Stabble (Stable/Weighted), and more.
+//!
+//! # Output Formats
+//!
+//! - **Protobuf** (primary): compact, language-agnostic [`SwapRecord`] messages
+//! - **ClickHouse** (optional, behind `clickhouse-output` feature): direct table writes
+//!
+//! # Usage as a Plugin
+//!
+//! ```ignore
+//! use jetstreamer::JetstreamerRunner;
+//! use jetstreamer_dex_trades::DexTradesPlugin;
+//!
+//! JetstreamerRunner::new()
+//!     .with_plugin(Box::new(DexTradesPlugin::new()))
+//!     .parse_cli_args().unwrap()
+//!     .run().unwrap();
+//! ```
+//!
+//! # Usage as a Library
+//!
+//! ```no_run
+//! use jetstreamer_dex_trades::registry::DexRegistry;
+//! // Bring the extension trait into scope to call .all_instructions() etc.
+//! use jetstreamer_dex_trades::instruction_iter::InstructionIteratorExt;
+//!
+//! let registry = DexRegistry::new();
+//! // registry.decode_transaction(&tx_data) returns Vec<SwapRecord>
+//! ```
+
+pub mod instruction_iter;
+pub mod transaction_ext;
+pub mod log_parser;
+pub mod token_transfers;
+pub mod types;
+pub mod registry;
+pub mod plugin;
+pub mod decoders;
+
+/// Generated protobuf types.
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/dex_trades.rs"));
+}
+
+pub use plugin::DexTradesPlugin;
+pub use registry::DexRegistry;
+pub use types::SwapRecord;

--- a/jetstreamer-dex-trades/src/lib.rs
+++ b/jetstreamer-dex-trades/src/lib.rs
@@ -1,3 +1,10 @@
+#![allow(
+    clippy::field_reassign_with_default,
+    clippy::too_many_arguments,
+    clippy::large_enum_variant,
+    clippy::type_complexity
+)]
+
 //! Solana DEX trades decoder plugin for Jetstreamer.
 //!
 //! Decodes swap transactions from 28+ Solana DEX programs into a unified
@@ -40,14 +47,14 @@
 //! // registry.decode_transaction(&tx_data) returns Vec<SwapRecord>
 //! ```
 
-pub mod instruction_iter;
-pub mod transaction_ext;
-pub mod log_parser;
-pub mod token_transfers;
-pub mod types;
-pub mod registry;
-pub mod plugin;
 pub mod decoders;
+pub mod instruction_iter;
+pub mod log_parser;
+pub mod plugin;
+pub mod registry;
+pub mod token_transfers;
+pub mod transaction_ext;
+pub mod types;
 
 /// Generated protobuf types.
 pub mod proto {

--- a/jetstreamer-dex-trades/src/log_parser.rs
+++ b/jetstreamer-dex-trades/src/log_parser.rs
@@ -1,0 +1,200 @@
+//! Log parser for extracting events from Solana transaction logs.
+//!
+//! Maps `Program log:` and `Program data:` messages to their instruction
+//! positions, enabling event-based decoding for DEXes like Raydium AMM V4
+//! and Anchor-style programs.
+
+use std::collections::HashMap;
+
+#[derive(Debug, Clone)]
+struct ProgramContext {
+    program_id: String,
+    #[allow(dead_code)]
+    depth: u32,
+    instruction_position: String,
+}
+
+struct PositionTracker {
+    outer_index: usize,
+    current_inner_count: usize,
+}
+
+impl PositionTracker {
+    fn new() -> Self {
+        Self {
+            outer_index: 0,
+            current_inner_count: 0,
+        }
+    }
+
+    fn on_invoke(&mut self, depth: u32) -> String {
+        if depth == 1 {
+            self.outer_index += 1;
+            self.current_inner_count = 0;
+            return self.outer_index.to_string();
+        }
+        self.current_inner_count += 1;
+        format!("{}.{}", self.outer_index, self.current_inner_count)
+    }
+}
+
+/// Log parser for extracting events by instruction position.
+pub struct LogParser;
+
+impl LogParser {
+    /// Extract `Program log:` messages grouped by instruction position.
+    pub fn extract_program_logs_by_position(
+        logs: &[String],
+        target_program: &str,
+    ) -> HashMap<String, Vec<String>> {
+        let mut result: HashMap<String, Vec<String>> = HashMap::new();
+        let mut stack: Vec<ProgramContext> = Vec::new();
+        let mut tracker = PositionTracker::new();
+
+        for log in logs {
+            if let Some((program_id, depth)) = Self::parse_invoke(log) {
+                let position = tracker.on_invoke(depth);
+                stack.push(ProgramContext {
+                    program_id,
+                    depth,
+                    instruction_position: position,
+                });
+            } else if let Some(program_id) = Self::parse_completion(log) {
+                if let Some(pos) = stack.iter().rposition(|ctx| ctx.program_id == program_id) {
+                    stack.remove(pos);
+                }
+            } else if let Some(log_msg) = log.strip_prefix("Program log: ") {
+                if let Some(ctx) = stack.last() {
+                    if ctx.program_id == target_program {
+                        result
+                            .entry(ctx.instruction_position.clone())
+                            .or_default()
+                            .push(log_msg.to_string());
+                    }
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Extract `Program data:` events grouped by instruction position.
+    pub fn extract_program_data_by_position(
+        logs: &[String],
+        target_program: &str,
+    ) -> HashMap<String, Vec<String>> {
+        let mut result: HashMap<String, Vec<String>> = HashMap::new();
+        let mut stack: Vec<ProgramContext> = Vec::new();
+        let mut tracker = PositionTracker::new();
+
+        for log in logs {
+            if let Some((program_id, depth)) = Self::parse_invoke(log) {
+                let position = tracker.on_invoke(depth);
+                stack.push(ProgramContext {
+                    program_id,
+                    depth,
+                    instruction_position: position,
+                });
+            } else if let Some(program_id) = Self::parse_completion(log) {
+                if let Some(pos) = stack.iter().rposition(|ctx| ctx.program_id == program_id) {
+                    stack.remove(pos);
+                }
+            } else if let Some(data) = log.strip_prefix("Program data: ") {
+                if let Some(ctx) = stack.last() {
+                    if ctx.program_id == target_program {
+                        result
+                            .entry(ctx.instruction_position.clone())
+                            .or_default()
+                            .push(data.to_string());
+                    }
+                }
+            }
+        }
+
+        result
+    }
+
+    /// Returns true if any log line contains "Log truncated".
+    pub fn is_truncated(logs: &[String]) -> bool {
+        logs.iter().any(|l| l.contains("Log truncated"))
+    }
+
+    fn parse_invoke(log: &str) -> Option<(String, u32)> {
+        if log.starts_with("Program ") && log.contains(" invoke [") && log.ends_with(']') {
+            let parts: Vec<&str> = log.split_whitespace().collect();
+            if parts.len() >= 4 && parts[0] == "Program" && parts[2] == "invoke" {
+                let program_id = parts[1].to_string();
+                let depth_str = parts[3].trim_start_matches('[').trim_end_matches(']');
+                if let Ok(depth) = depth_str.parse::<u32>() {
+                    return Some((program_id, depth));
+                }
+            }
+        }
+        None
+    }
+
+    fn parse_completion(log: &str) -> Option<String> {
+        if log.starts_with("Program ") {
+            let parts: Vec<&str> = log.split_whitespace().collect();
+            if parts.len() >= 3
+                && parts[0] == "Program"
+                && (parts[2] == "success" || parts[2].starts_with("failed"))
+            {
+                return Some(parts[1].to_string());
+            }
+        }
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_program_logs() {
+        let logs = vec![
+            "Program 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8 invoke [1]".to_string(),
+            "Program log: ray_log: SGVsbG8=".to_string(),
+            "Program 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8 success".to_string(),
+        ];
+
+        let result = LogParser::extract_program_logs_by_position(
+            &logs,
+            "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8",
+        );
+
+        assert_eq!(
+            result.get("1"),
+            Some(&vec!["ray_log: SGVsbG8=".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_nested_cpi() {
+        let logs = vec![
+            "Program JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 invoke [1]".to_string(),
+            "Program 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8 invoke [2]".to_string(),
+            "Program log: ray_log: first_swap".to_string(),
+            "Program 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8 success".to_string(),
+            "Program 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8 invoke [2]".to_string(),
+            "Program log: ray_log: second_swap".to_string(),
+            "Program 675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8 success".to_string(),
+            "Program JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4 success".to_string(),
+        ];
+
+        let result = LogParser::extract_program_logs_by_position(
+            &logs,
+            "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8",
+        );
+
+        assert_eq!(
+            result.get("1.1"),
+            Some(&vec!["ray_log: first_swap".to_string()])
+        );
+        assert_eq!(
+            result.get("1.2"),
+            Some(&vec!["ray_log: second_swap".to_string()])
+        );
+    }
+}

--- a/jetstreamer-dex-trades/src/log_parser.rs
+++ b/jetstreamer-dex-trades/src/log_parser.rs
@@ -63,15 +63,14 @@ impl LogParser {
                 if let Some(pos) = stack.iter().rposition(|ctx| ctx.program_id == program_id) {
                     stack.remove(pos);
                 }
-            } else if let Some(log_msg) = log.strip_prefix("Program log: ") {
-                if let Some(ctx) = stack.last() {
-                    if ctx.program_id == target_program {
-                        result
-                            .entry(ctx.instruction_position.clone())
-                            .or_default()
-                            .push(log_msg.to_string());
-                    }
-                }
+            } else if let Some(log_msg) = log.strip_prefix("Program log: ")
+                && let Some(ctx) = stack.last()
+                && ctx.program_id == target_program
+            {
+                result
+                    .entry(ctx.instruction_position.clone())
+                    .or_default()
+                    .push(log_msg.to_string());
             }
         }
 
@@ -99,15 +98,14 @@ impl LogParser {
                 if let Some(pos) = stack.iter().rposition(|ctx| ctx.program_id == program_id) {
                     stack.remove(pos);
                 }
-            } else if let Some(data) = log.strip_prefix("Program data: ") {
-                if let Some(ctx) = stack.last() {
-                    if ctx.program_id == target_program {
-                        result
-                            .entry(ctx.instruction_position.clone())
-                            .or_default()
-                            .push(data.to_string());
-                    }
-                }
+            } else if let Some(data) = log.strip_prefix("Program data: ")
+                && let Some(ctx) = stack.last()
+                && ctx.program_id == target_program
+            {
+                result
+                    .entry(ctx.instruction_position.clone())
+                    .or_default()
+                    .push(data.to_string());
             }
         }
 

--- a/jetstreamer-dex-trades/src/plugin.rs
+++ b/jetstreamer-dex-trades/src/plugin.rs
@@ -50,15 +50,17 @@ impl DexTradesPlugin {
     }
 
     /// Create a plugin with a callback that receives `(slot, protobuf_bytes)`.
-    pub fn with_batch_callback(
-        callback: impl Fn(u64, Vec<u8>) + Send + Sync + 'static,
-    ) -> Self {
+    pub fn with_batch_callback(callback: impl Fn(u64, Vec<u8>) + Send + Sync + 'static) -> Self {
         Self {
             on_batch: Some(Arc::new(callback)),
         }
     }
 
-    fn flush_slot(slot: u64, block_time: i64, on_batch: &Option<Arc<dyn Fn(u64, Vec<u8>) + Send + Sync>>) {
+    fn flush_slot(
+        slot: u64,
+        block_time: i64,
+        on_batch: &Option<Arc<dyn Fn(u64, Vec<u8>) + Send + Sync>>,
+    ) {
         if let Some((_, records)) = PENDING_BY_SLOT.remove(&slot) {
             if records.is_empty() {
                 return;
@@ -86,21 +88,43 @@ impl DexTradesPlugin {
                          txn_fee:     {:.9}  priority_fee: {:.9}  jito_tips: {:.9}\n\
                          sqrt_price:  {}  direction: {}\n\
                          CU consumed: {}",
-                        slot, block_date, i + 1, records.len(),
+                        slot,
+                        block_date,
+                        i + 1,
+                        records.len(),
                         r.tx_id,
-                        r.tx_index, r.instruction_index, r.inner_instruction_index, r.is_inner_instruction,
+                        r.tx_index,
+                        r.instruction_index,
+                        r.inner_instruction_index,
+                        r.is_inner_instruction,
                         r.instruction_type,
                         r.outer_program,
                         r.inner_program,
                         r.pool_address,
                         r.signer,
-                        r.token_bought_mint, r.token_bought_decimals, r.token_bought_amount,
-                        r.token_bought_vault, r.token_bought_vault_reserve,
-                        r.token_sold_mint, r.token_sold_decimals, r.token_sold_amount,
-                        r.token_sold_vault, r.token_sold_vault_reserve,
-                        r.txn_fee, r.priority_fee, r.jito_tips,
-                        if r.sqrt_price.is_empty() { "-" } else { &r.sqrt_price },
-                        match r.is_base_to_quote { Some(true) => "base→quote", Some(false) => "quote→base", None => "-" },
+                        r.token_bought_mint,
+                        r.token_bought_decimals,
+                        r.token_bought_amount,
+                        r.token_bought_vault,
+                        r.token_bought_vault_reserve,
+                        r.token_sold_mint,
+                        r.token_sold_decimals,
+                        r.token_sold_amount,
+                        r.token_sold_vault,
+                        r.token_sold_vault_reserve,
+                        r.txn_fee,
+                        r.priority_fee,
+                        r.jito_tips,
+                        if r.sqrt_price.is_empty() {
+                            "-"
+                        } else {
+                            &r.sqrt_price
+                        },
+                        match r.is_base_to_quote {
+                            Some(true) => "base→quote",
+                            Some(false) => "quote→base",
+                            None => "-",
+                        },
                         r.compute_units_consumed,
                     );
                 }

--- a/jetstreamer-dex-trades/src/plugin.rs
+++ b/jetstreamer-dex-trades/src/plugin.rs
@@ -1,0 +1,213 @@
+//! Jetstreamer [`Plugin`] implementation that decodes DEX swaps into protobuf.
+
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use futures_util::FutureExt;
+use jetstreamer_firehose::firehose::{BlockData, TransactionData};
+use jetstreamer_plugin::{Plugin, PluginFuture};
+use once_cell::sync::Lazy;
+use prost::Message;
+
+use crate::proto::DexTradesBatch;
+use crate::registry::DexRegistry;
+use crate::types::SwapRecord;
+
+/// Pending swap records keyed by slot, waiting for block_time from `on_block`.
+static PENDING_BY_SLOT: Lazy<DashMap<u64, Vec<SwapRecord>>> = Lazy::new(DashMap::new);
+
+/// Global registry shared across threads.
+static REGISTRY: Lazy<DexRegistry> = Lazy::new(DexRegistry::new);
+
+/// When `DEX_TRADES_DUMP=1` is set, each decoded swap is printed to stdout.
+static DUMP_ENABLED: Lazy<bool> = Lazy::new(|| {
+    std::env::var("DEX_TRADES_DUMP")
+        .map(|v| matches!(v.as_str(), "1" | "true" | "yes"))
+        .unwrap_or(false)
+});
+
+/// DEX trades decoder plugin for Jetstreamer.
+///
+/// Decodes swap transactions from 28+ Solana DEX programs and emits
+/// protobuf-encoded [`DexTradesBatch`] messages.
+///
+/// # Lifecycle
+///
+/// 1. `on_load` — logs startup info.
+/// 2. `on_transaction` — decodes swaps (without block_time) and buffers them.
+/// 3. `on_block` — applies block_time, encodes protobuf, and flushes.
+/// 4. `on_exit` — drains any remaining buffered records.
+pub struct DexTradesPlugin {
+    /// Optional callback invoked with each encoded protobuf batch.
+    /// Consumers can use this to write to files, send over the network, etc.
+    on_batch: Option<Arc<dyn Fn(u64, Vec<u8>) + Send + Sync>>,
+}
+
+impl DexTradesPlugin {
+    /// Create a new plugin that logs decoded batches (no persistence).
+    pub fn new() -> Self {
+        Self { on_batch: None }
+    }
+
+    /// Create a plugin with a callback that receives `(slot, protobuf_bytes)`.
+    pub fn with_batch_callback(
+        callback: impl Fn(u64, Vec<u8>) + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            on_batch: Some(Arc::new(callback)),
+        }
+    }
+
+    fn flush_slot(slot: u64, block_time: i64, on_batch: &Option<Arc<dyn Fn(u64, Vec<u8>) + Send + Sync>>) {
+        if let Some((_, records)) = PENDING_BY_SLOT.remove(&slot) {
+            if records.is_empty() {
+                return;
+            }
+
+            let block_date = chrono::DateTime::from_timestamp(block_time, 0)
+                .map(|dt| dt.date_naive())
+                .unwrap_or_else(|| chrono::NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
+
+            if *DUMP_ENABLED {
+                for (i, r) in records.iter().enumerate() {
+                    println!(
+                        "─── slot={} date={} swap {}/{} ───\n\
+                         tx_id:       {}\n\
+                         tx_index:    {}  ix: {}.{}  inner: {}\n\
+                         ix_type:     {}\n\
+                         outer_prog:  {}\n\
+                         inner_prog:  {}\n\
+                         pool:        {}\n\
+                         signer:      {}\n\
+                         bought:      {} (decimals={})  amount={:.10}\n\
+                         bought_vault:{} reserve={:.6}\n\
+                         sold:        {} (decimals={})  amount={:.10}\n\
+                         sold_vault:  {} reserve={:.6}\n\
+                         txn_fee:     {:.9}  priority_fee: {:.9}  jito_tips: {:.9}\n\
+                         sqrt_price:  {}  direction: {}\n\
+                         CU consumed: {}",
+                        slot, block_date, i + 1, records.len(),
+                        r.tx_id,
+                        r.tx_index, r.instruction_index, r.inner_instruction_index, r.is_inner_instruction,
+                        r.instruction_type,
+                        r.outer_program,
+                        r.inner_program,
+                        r.pool_address,
+                        r.signer,
+                        r.token_bought_mint, r.token_bought_decimals, r.token_bought_amount,
+                        r.token_bought_vault, r.token_bought_vault_reserve,
+                        r.token_sold_mint, r.token_sold_decimals, r.token_sold_amount,
+                        r.token_sold_vault, r.token_sold_vault_reserve,
+                        r.txn_fee, r.priority_fee, r.jito_tips,
+                        if r.sqrt_price.is_empty() { "-" } else { &r.sqrt_price },
+                        match r.is_base_to_quote { Some(true) => "base→quote", Some(false) => "quote→base", None => "-" },
+                        r.compute_units_consumed,
+                    );
+                }
+            }
+
+            let proto_records: Vec<crate::proto::SwapRecord> = records
+                .iter()
+                .map(|r| {
+                    let mut pr = r.to_proto();
+                    pr.block_time = block_time;
+                    pr.block_date = block_date.format("%Y-%m-%d").to_string();
+                    pr
+                })
+                .collect();
+
+            let count = proto_records.len();
+            let batch = DexTradesBatch {
+                slot,
+                block_time,
+                records: proto_records,
+            };
+
+            let bytes = batch.encode_to_vec();
+
+            log::info!(
+                "dex-trades: slot {} — {} swaps, {} bytes protobuf",
+                slot,
+                count,
+                bytes.len()
+            );
+
+            if let Some(cb) = on_batch {
+                cb(slot, bytes);
+            }
+        }
+    }
+}
+
+impl Default for DexTradesPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for DexTradesPlugin {
+    fn name(&self) -> &'static str {
+        "DEX Trades"
+    }
+
+    fn on_load(&self, _db: Option<Arc<clickhouse::Client>>) -> PluginFuture<'_> {
+        async move {
+            log::info!(
+                "DEX Trades Plugin loaded — {} decoders, {} program IDs",
+                REGISTRY.decoder_count(),
+                REGISTRY.supported_program_ids().len()
+            );
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn on_transaction<'a>(
+        &'a self,
+        _thread_id: usize,
+        _db: Option<Arc<clickhouse::Client>>,
+        transaction: &'a TransactionData,
+    ) -> PluginFuture<'a> {
+        async move {
+            // Decode with block_time=0; the real value is applied in on_block.
+            let swaps = REGISTRY.decode_transaction(transaction, 0);
+            if !swaps.is_empty() {
+                PENDING_BY_SLOT
+                    .entry(transaction.slot)
+                    .or_default()
+                    .extend(swaps);
+            }
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn on_block<'a>(
+        &'a self,
+        _thread_id: usize,
+        _db: Option<Arc<clickhouse::Client>>,
+        block: &'a BlockData,
+    ) -> PluginFuture<'a> {
+        let slot = block.slot();
+        let block_time = block.block_time().unwrap_or(0);
+        let on_batch = self.on_batch.clone();
+        async move {
+            Self::flush_slot(slot, block_time, &on_batch);
+            Ok(())
+        }
+        .boxed()
+    }
+
+    fn on_exit(&self, _db: Option<Arc<clickhouse::Client>>) -> PluginFuture<'_> {
+        let on_batch = self.on_batch.clone();
+        async move {
+            let slots: Vec<u64> = PENDING_BY_SLOT.iter().map(|e| *e.key()).collect();
+            for slot in slots {
+                Self::flush_slot(slot, 0, &on_batch);
+            }
+            log::info!("DEX Trades Plugin exiting.");
+            Ok(())
+        }
+        .boxed()
+    }
+}

--- a/jetstreamer-dex-trades/src/registry.rs
+++ b/jetstreamer-dex-trades/src/registry.rs
@@ -1,0 +1,294 @@
+//! DEX decoder registry — dispatches transactions to the correct decoder.
+
+use crate::instruction_iter::{Instruction, InstructionIteratorExt};
+use crate::transaction_ext::TransactionExt;
+use crate::types::SwapRecord;
+use chrono::NaiveDate;
+use jetstreamer_firehose::firehose::TransactionData;
+use std::collections::HashMap;
+
+const SOL_DECIMALS: i32 = 9;
+
+/// Transaction-level common fields computed once per transaction.
+#[derive(Clone)]
+pub struct TxContext {
+    pub block_slot: u64,
+    pub block_time: i64,
+    pub block_date: NaiveDate,
+    pub tx_id: String,
+    pub tx_index: u32,
+    pub signer: String,
+    pub txn_fee: f64,
+    pub priority_fee: f64,
+    pub jito_tips: f64,
+    pub compute_units_consumed: u64,
+}
+
+impl TxContext {
+    /// Build context from a transaction.
+    ///
+    /// `block_time` is passed in separately because the public jetstreamer
+    /// `TransactionData` does not carry it (it lives on `BlockData`).
+    pub fn from_tx(tx: &TransactionData, block_time: i64) -> Self {
+        let block_date = chrono::DateTime::from_timestamp(block_time, 0)
+            .map(|dt| dt.date_naive())
+            .unwrap_or_else(|| NaiveDate::from_ymd_opt(1970, 1, 1).unwrap());
+
+        let account_keys = tx.account_keys();
+        let signer = account_keys
+            .first()
+            .map(|a| a.to_string())
+            .unwrap_or_default();
+
+        Self {
+            block_slot: tx.slot,
+            block_time,
+            block_date,
+            tx_id: tx.signature.to_string(),
+            tx_index: tx.transaction_slot_index as u32,
+            signer,
+            txn_fee: tx.get_total_fee() as f64 / 10f64.powi(SOL_DECIMALS),
+            priority_fee: tx.get_priority_fee() as f64 / 10f64.powi(SOL_DECIMALS),
+            jito_tips: tx.get_jito_tips() as f64 / 10f64.powi(SOL_DECIMALS),
+            compute_units_consumed: tx
+                .transaction_status_meta
+                .compute_units_consumed
+                .unwrap_or(0),
+        }
+    }
+
+    pub fn apply_to(&self, record: &mut SwapRecord) {
+        record.block_slot = self.block_slot;
+        record.block_time = self.block_time;
+        record.block_date = self.block_date;
+        record.tx_id = self.tx_id.clone();
+        record.tx_index = self.tx_index;
+        record.signer = self.signer.clone();
+        record.txn_fee = self.txn_fee;
+        record.priority_fee = self.priority_fee;
+        record.jito_tips = self.jito_tips;
+        record.compute_units_consumed = self.compute_units_consumed;
+    }
+}
+
+/// Trait that all DEX decoders implement.
+pub trait DexDecoder: Send + Sync {
+    fn name(&self) -> &'static str;
+    fn program_ids(&self) -> &[&'static str];
+
+    /// Decode a single instruction. Returns `Some(SwapRecord)` with
+    /// swap-specific fields filled; the registry will apply common fields.
+    fn decode_instruction(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Option<SwapRecord>;
+
+    /// Decode instruction(s) — override for multi-hop swaps that produce
+    /// multiple records from one instruction.
+    fn decode_instructions(
+        &self,
+        tx: &TransactionData,
+        ix: &Instruction,
+        outer_program: &str,
+    ) -> Vec<SwapRecord> {
+        self.decode_instruction(tx, ix, outer_program)
+            .into_iter()
+            .collect()
+    }
+
+    fn on_transaction_start(&self, _tx: &TransactionData) {}
+    fn on_transaction_end(&self, _tx_id: &str) {}
+}
+
+/// Registry of all DEX decoders. Maps program IDs to decoder instances and
+/// drives the decoding loop.
+pub struct DexRegistry {
+    decoders: Vec<Box<dyn DexDecoder>>,
+    program_map: HashMap<String, usize>,
+}
+
+impl Default for DexRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl DexRegistry {
+    pub fn new() -> Self {
+        let mut registry = Self {
+            decoders: Vec::new(),
+            program_map: HashMap::new(),
+        };
+
+        crate::decoders::register_all(&mut registry);
+
+        log::info!(
+            "registered {} DEX decoders covering {} program IDs",
+            registry.decoders.len(),
+            registry.program_map.len()
+        );
+
+        registry
+    }
+
+    /// Register a single decoder.
+    pub fn register(&mut self, decoder: Box<dyn DexDecoder>) {
+        let index = self.decoders.len();
+        for program_id in decoder.program_ids() {
+            self.program_map.insert(program_id.to_string(), index);
+        }
+        log::info!(
+            "  {} ({})",
+            decoder.name(),
+            decoder.program_ids().join(", ")
+        );
+        self.decoders.push(decoder);
+    }
+
+    /// Decode all swaps from a transaction.
+    ///
+    /// `block_time` must be supplied because the public `TransactionData`
+    /// struct does not include it.
+    pub fn decode_transaction(
+        &self,
+        tx: &TransactionData,
+        block_time: i64,
+    ) -> Vec<SwapRecord> {
+        if tx.is_vote_transaction() || tx.is_failed() {
+            return Vec::new();
+        }
+
+        let mut swaps = Vec::new();
+        let tx_id = tx.signature.to_string();
+        let mut active_decoders = Vec::new();
+        let mut outer_programs: HashMap<usize, String> = HashMap::new();
+
+        for ix in tx.all_instructions() {
+            let program_id = ix.program_id().to_string();
+
+            if let Instruction::TopLevel { index, .. } = &ix {
+                outer_programs.insert(*index, program_id.clone());
+            }
+
+            let decoder_idx = match self.program_map.get(&program_id) {
+                Some(&idx) => idx,
+                None => continue,
+            };
+
+            let decoder = &self.decoders[decoder_idx];
+
+            if !active_decoders.contains(&decoder_idx) {
+                decoder.on_transaction_start(tx);
+                active_decoders.push(decoder_idx);
+            }
+
+            let outer_program = match &ix {
+                Instruction::TopLevel { .. } => program_id.clone(),
+                Instruction::Inner { parent_index, .. } => outer_programs
+                    .get(parent_index)
+                    .cloned()
+                    .unwrap_or_default(),
+            };
+
+            let decoded = decoder.decode_instructions(tx, &ix, &outer_program);
+            swaps.extend(decoded);
+        }
+
+        for idx in active_decoders {
+            self.decoders[idx].on_transaction_end(&tx_id);
+        }
+
+        if !swaps.is_empty() {
+            let tx_context = TxContext::from_tx(tx, block_time);
+            for swap in &mut swaps {
+                tx_context.apply_to(swap);
+            }
+        }
+
+        swaps
+    }
+
+    pub fn decoder_count(&self) -> usize {
+        self.decoders.len()
+    }
+
+    pub fn supported_program_ids(&self) -> Vec<&str> {
+        self.decoders
+            .iter()
+            .flat_map(|d| d.program_ids().iter().copied())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_registry_registers_all_decoders() {
+        let registry = DexRegistry::new();
+        assert!(
+            registry.decoder_count() >= 30,
+            "expected >= 30 decoders, got {}",
+            registry.decoder_count()
+        );
+    }
+
+    #[test]
+    fn test_registry_covers_expected_programs() {
+        let registry = DexRegistry::new();
+        let program_ids = registry.supported_program_ids();
+
+        let expected = [
+            "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P",  // Pump Fun
+            "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA",  // Pump AMM
+            "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8",  // Raydium AMM V4
+            "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C",  // Raydium CPMM
+            "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK",  // Raydium CLMM
+            "LanMV9sAd7wArD4vJFi2qDdfnVhFxYSUg6eADduJ3uj",  // Raydium LaunchLab
+            "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",  // Orca Whirlpool
+            "9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP",  // Orca V2
+            "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG",  // Meteora DAMM V2
+            "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN",  // Meteora DBC
+            "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo",  // Meteora DLMM
+            "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB",  // Meteora Pools
+            "MNFSTqtC93rEfYHB6hF82sKdZpUDFWkViLByLd1k1Ms",  // Manifest
+            "AQU1FRd7papthgdrwPTTq5JacJh8YtwEXaBfKU3bTz45",  // Aquifer
+            "obriQD1zbpyLz95G5n7nJe6a4DPjpFwa5XYPoNm113y",  // Obric V2
+            "swapNyd8XiQwJ6ianp9snpu4brUqFxadzvHebnAXjJZ",  // Stabble Stable
+            "swapFpHZwjELNnjvThjajtiVmkz3yPQEHjLtka2fwHW",  // Stabble Weighted
+            "EewxydAPCCVuNEyrVN68PuSYdQ7wKn27V9Gjeoi8dy3S",  // Lifinity V1
+            "2wT8Yq49kHgDzXuPxZSaeLaH1qbmGXtEyPy64bL7aD3c",  // Lifinity V2
+            "FUTARELBfJfQ8RDGhg1wdhddq1odMAJUePHFuBYfUxKq",  // Futarchy AMM
+            "HpNfyc2Saw7RKkQd8nEL4khUcuPhQ7WwY1B2qjx8jxFq",  // PancakeSwap CLMM
+            "REALQqNEomY6cQGZJUGwywTBD2UmDT32rZcNnfxQ5N2",  // Byreal CLMM
+            "SoLFiHG9TfgtdUXUjWAxi3LtvYuFyDLVhBWxdMZxyCe",  // SolFi V1
+            "SV2EYYJyRz2YhfXwXnhNAevDEui5Q6yrfyo13WtupPF",  // SolFi V2
+            "ALPHAQmeA7bjrVuccPsYPiCvsi428SNwte66Srvs4pHA",  // AlphaQ
+        ];
+
+        for program_id in &expected {
+            assert!(
+                program_ids.contains(program_id),
+                "missing program ID: {}",
+                program_id
+            );
+        }
+    }
+
+    #[test]
+    fn test_no_duplicate_program_ids() {
+        let registry = DexRegistry::new();
+        let program_ids = registry.supported_program_ids();
+        let mut seen = std::collections::HashSet::new();
+        for id in &program_ids {
+            assert!(
+                seen.insert(id),
+                "duplicate program ID registered: {}",
+                id
+            );
+        }
+    }
+}

--- a/jetstreamer-dex-trades/src/registry.rs
+++ b/jetstreamer-dex-trades/src/registry.rs
@@ -151,11 +151,7 @@ impl DexRegistry {
     ///
     /// `block_time` must be supplied because the public `TransactionData`
     /// struct does not include it.
-    pub fn decode_transaction(
-        &self,
-        tx: &TransactionData,
-        block_time: i64,
-    ) -> Vec<SwapRecord> {
+    pub fn decode_transaction(&self, tx: &TransactionData, block_time: i64) -> Vec<SwapRecord> {
         if tx.is_vote_transaction() || tx.is_failed() {
             return Vec::new();
         }
@@ -242,31 +238,31 @@ mod tests {
         let program_ids = registry.supported_program_ids();
 
         let expected = [
-            "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P",  // Pump Fun
-            "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA",  // Pump AMM
-            "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8",  // Raydium AMM V4
-            "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C",  // Raydium CPMM
-            "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK",  // Raydium CLMM
-            "LanMV9sAd7wArD4vJFi2qDdfnVhFxYSUg6eADduJ3uj",  // Raydium LaunchLab
-            "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc",  // Orca Whirlpool
-            "9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP",  // Orca V2
-            "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG",  // Meteora DAMM V2
-            "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN",  // Meteora DBC
-            "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo",  // Meteora DLMM
-            "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB",  // Meteora Pools
-            "MNFSTqtC93rEfYHB6hF82sKdZpUDFWkViLByLd1k1Ms",  // Manifest
-            "AQU1FRd7papthgdrwPTTq5JacJh8YtwEXaBfKU3bTz45",  // Aquifer
-            "obriQD1zbpyLz95G5n7nJe6a4DPjpFwa5XYPoNm113y",  // Obric V2
-            "swapNyd8XiQwJ6ianp9snpu4brUqFxadzvHebnAXjJZ",  // Stabble Stable
-            "swapFpHZwjELNnjvThjajtiVmkz3yPQEHjLtka2fwHW",  // Stabble Weighted
-            "EewxydAPCCVuNEyrVN68PuSYdQ7wKn27V9Gjeoi8dy3S",  // Lifinity V1
-            "2wT8Yq49kHgDzXuPxZSaeLaH1qbmGXtEyPy64bL7aD3c",  // Lifinity V2
-            "FUTARELBfJfQ8RDGhg1wdhddq1odMAJUePHFuBYfUxKq",  // Futarchy AMM
-            "HpNfyc2Saw7RKkQd8nEL4khUcuPhQ7WwY1B2qjx8jxFq",  // PancakeSwap CLMM
-            "REALQqNEomY6cQGZJUGwywTBD2UmDT32rZcNnfxQ5N2",  // Byreal CLMM
-            "SoLFiHG9TfgtdUXUjWAxi3LtvYuFyDLVhBWxdMZxyCe",  // SolFi V1
-            "SV2EYYJyRz2YhfXwXnhNAevDEui5Q6yrfyo13WtupPF",  // SolFi V2
-            "ALPHAQmeA7bjrVuccPsYPiCvsi428SNwte66Srvs4pHA",  // AlphaQ
+            "6EF8rrecthR5Dkzon8Nwu78hRvfCKubJ14M5uBEwF6P", // Pump Fun
+            "pAMMBay6oceH9fJKBRHGP5D4bD4sWpmSwMn52FMfXEA", // Pump AMM
+            "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8", // Raydium AMM V4
+            "CPMMoo8L3F4NbTegBCKVNunggL7H1ZpdTHKxQB5qKP1C", // Raydium CPMM
+            "CAMMCzo5YL8w4VFF8KVHrK22GGUsp5VTaW7grrKgrWqK", // Raydium CLMM
+            "LanMV9sAd7wArD4vJFi2qDdfnVhFxYSUg6eADduJ3uj", // Raydium LaunchLab
+            "whirLbMiicVdio4qvUfM5KAg6Ct8VwpYzGff3uctyCc", // Orca Whirlpool
+            "9W959DqEETiGZocYWCQPaJ6sBmUzgfxXfqGeTEdp3aQP", // Orca V2
+            "cpamdpZCGKUy5JxQXB4dcpGPiikHawvSWAd6mEn1sGG", // Meteora DAMM V2
+            "dbcij3LWUppWqq96dh6gJWwBifmcGfLSB5D4DuSMaqN", // Meteora DBC
+            "LBUZKhRxPF3XUpBCjp4YzTKgLccjZhTSDM9YuVaPwxo", // Meteora DLMM
+            "Eo7WjKq67rjJQSZxS6z3YkapzY3eMj6Xy8X5EQVn5UaB", // Meteora Pools
+            "MNFSTqtC93rEfYHB6hF82sKdZpUDFWkViLByLd1k1Ms", // Manifest
+            "AQU1FRd7papthgdrwPTTq5JacJh8YtwEXaBfKU3bTz45", // Aquifer
+            "obriQD1zbpyLz95G5n7nJe6a4DPjpFwa5XYPoNm113y", // Obric V2
+            "swapNyd8XiQwJ6ianp9snpu4brUqFxadzvHebnAXjJZ", // Stabble Stable
+            "swapFpHZwjELNnjvThjajtiVmkz3yPQEHjLtka2fwHW", // Stabble Weighted
+            "EewxydAPCCVuNEyrVN68PuSYdQ7wKn27V9Gjeoi8dy3S", // Lifinity V1
+            "2wT8Yq49kHgDzXuPxZSaeLaH1qbmGXtEyPy64bL7aD3c", // Lifinity V2
+            "FUTARELBfJfQ8RDGhg1wdhddq1odMAJUePHFuBYfUxKq", // Futarchy AMM
+            "HpNfyc2Saw7RKkQd8nEL4khUcuPhQ7WwY1B2qjx8jxFq", // PancakeSwap CLMM
+            "REALQqNEomY6cQGZJUGwywTBD2UmDT32rZcNnfxQ5N2", // Byreal CLMM
+            "SoLFiHG9TfgtdUXUjWAxi3LtvYuFyDLVhBWxdMZxyCe", // SolFi V1
+            "SV2EYYJyRz2YhfXwXnhNAevDEui5Q6yrfyo13WtupPF", // SolFi V2
+            "ALPHAQmeA7bjrVuccPsYPiCvsi428SNwte66Srvs4pHA", // AlphaQ
         ];
 
         for program_id in &expected {
@@ -284,11 +280,7 @@ mod tests {
         let program_ids = registry.supported_program_ids();
         let mut seen = std::collections::HashSet::new();
         for id in &program_ids {
-            assert!(
-                seen.insert(id),
-                "duplicate program ID registered: {}",
-                id
-            );
+            assert!(seen.insert(id), "duplicate program ID registered: {}", id);
         }
     }
 }

--- a/jetstreamer-dex-trades/src/token_transfers.rs
+++ b/jetstreamer-dex-trades/src/token_transfers.rs
@@ -1,0 +1,416 @@
+//! Token transfer extraction utilities for DEX swap decoding.
+//!
+//! Parses SPL Token and Token-2022 Transfer/TransferChecked instructions from
+//! inner instructions to determine which tokens were bought/sold and in what
+//! amounts.
+
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_transaction_status::TransactionTokenBalance;
+
+const SPL_TOKEN_PROGRAM: &str = "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA";
+const TOKEN_2022_PROGRAM: &str = "TokenzQdBNbLqP5VEhdkAS6EPFLC1PHnBqCXEpPxuEb";
+
+const TRANSFER_DISCRIMINATOR: u8 = 3;
+const TRANSFER_CHECKED_DISCRIMINATOR: u8 = 12;
+
+/// Token account info resolved from pre/post token balances.
+#[derive(Debug, Clone)]
+pub struct TokenAccountInfo {
+    pub mint: String,
+    pub decimals: u8,
+    pub pre_balance: u64,
+    pub post_balance: u64,
+}
+
+impl TokenAccountInfo {
+    pub fn post_balance_scaled(&self) -> f64 {
+        self.post_balance as f64 / 10f64.powi(self.decimals as i32)
+    }
+}
+
+/// A single transfer detected in inner instructions.
+#[derive(Debug, Clone)]
+pub struct TransferInfo {
+    pub mint: String,
+    pub vault: String,
+    pub amount: u64,
+    pub decimals: u8,
+}
+
+impl TransferInfo {
+    pub fn amount_scaled(&self) -> f64 {
+        self.amount as f64 / 10f64.powi(self.decimals as i32)
+    }
+}
+
+/// Resolved swap amounts with direction.
+#[derive(Debug, Clone)]
+pub struct SwapAmounts {
+    /// Token the user sent (into vault).
+    pub sold: TransferInfo,
+    /// Token the user received (from vault).
+    pub bought: TransferInfo,
+}
+
+/// Partial swap amounts (one side may be missing in direct routing).
+#[derive(Debug, Clone)]
+pub struct PartialSwapAmounts {
+    pub sold: Option<TransferInfo>,
+    pub bought: Option<TransferInfo>,
+}
+
+/// Get token account info from pre/post token balances.
+pub fn get_token_account_info(tx: &TransactionData, account: &str) -> Option<TokenAccountInfo> {
+    let account_keys = get_all_account_keys(tx);
+    let account_index = account_keys
+        .iter()
+        .position(|k| k.to_string() == account)?;
+
+    let pre_balances = tx
+        .transaction_status_meta
+        .pre_token_balances
+        .as_ref()
+        .unwrap_or(&Vec::new())
+        .clone();
+    let post_balances = tx
+        .transaction_status_meta
+        .post_token_balances
+        .as_ref()
+        .unwrap_or(&Vec::new())
+        .clone();
+
+    let post_entry = post_balances
+        .iter()
+        .find(|b| b.account_index as usize == account_index);
+    let pre_entry = pre_balances
+        .iter()
+        .find(|b| b.account_index as usize == account_index);
+
+    let entry = post_entry.or(pre_entry)?;
+    let mint = entry.mint.clone();
+    let decimals = entry.ui_token_amount.decimals;
+
+    let pre_amount = pre_entry
+        .and_then(|e| e.ui_token_amount.amount.parse::<u64>().ok())
+        .unwrap_or(0);
+    let post_amount = post_entry
+        .and_then(|e| e.ui_token_amount.amount.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    Some(TokenAccountInfo {
+        mint,
+        decimals,
+        pre_balance: pre_amount,
+        post_balance: post_amount,
+    })
+}
+
+/// Get swap amounts by analyzing SPL Token transfers in inner instructions.
+///
+/// - `vault_a` / `vault_b`: the two pool vault addresses
+/// - `exclude_accounts`: accounts to skip (e.g. fee accounts)
+/// - `take_largest`: if true, take the largest transfer for each vault
+///   (needed for Stabble which sends multiple transfers)
+pub fn get_swap_amounts(
+    tx: &TransactionData,
+    outer_idx: usize,
+    _inner_idx: usize,
+    vault_a: &str,
+    vault_b: &str,
+    exclude_accounts: Option<&[&str]>,
+    take_largest: bool,
+) -> Option<SwapAmounts> {
+    let transfers = extract_transfers(tx, outer_idx, exclude_accounts);
+
+    let mut vault_a_in: Option<(u64, String, String)> = None; // amount, source, mint
+    let mut vault_a_out: Option<(u64, String, String)> = None;
+    let mut vault_b_in: Option<(u64, String, String)> = None;
+    let mut vault_b_out: Option<(u64, String, String)> = None;
+
+    for t in &transfers {
+        if t.destination == vault_a {
+            let entry = &mut vault_a_in;
+            if take_largest {
+                if entry.as_ref().map_or(true, |e| t.amount > e.0) {
+                    *entry = Some((t.amount, t.source.clone(), t.mint.clone()));
+                }
+            } else if entry.is_none() {
+                *entry = Some((t.amount, t.source.clone(), t.mint.clone()));
+            }
+        } else if t.source == vault_a {
+            let entry = &mut vault_a_out;
+            if take_largest {
+                if entry.as_ref().map_or(true, |e| t.amount > e.0) {
+                    *entry = Some((t.amount, t.destination.clone(), t.mint.clone()));
+                }
+            } else if entry.is_none() {
+                *entry = Some((t.amount, t.destination.clone(), t.mint.clone()));
+            }
+        }
+
+        if t.destination == vault_b {
+            let entry = &mut vault_b_in;
+            if take_largest {
+                if entry.as_ref().map_or(true, |e| t.amount > e.0) {
+                    *entry = Some((t.amount, t.source.clone(), t.mint.clone()));
+                }
+            } else if entry.is_none() {
+                *entry = Some((t.amount, t.source.clone(), t.mint.clone()));
+            }
+        } else if t.source == vault_b {
+            let entry = &mut vault_b_out;
+            if take_largest {
+                if entry.as_ref().map_or(true, |e| t.amount > e.0) {
+                    *entry = Some((t.amount, t.destination.clone(), t.mint.clone()));
+                }
+            } else if entry.is_none() {
+                *entry = Some((t.amount, t.destination.clone(), t.mint.clone()));
+            }
+        }
+    }
+
+    // Determine direction: user sends to one vault, receives from the other
+    let (sold_vault, sold_amount, sold_mint, bought_vault, bought_amount, bought_mint) =
+        if vault_a_in.is_some() && vault_b_out.is_some() {
+            let a_in = vault_a_in.unwrap();
+            let b_out = vault_b_out.unwrap();
+            (
+                vault_a.to_string(),
+                a_in.0,
+                a_in.2,
+                vault_b.to_string(),
+                b_out.0,
+                b_out.2,
+            )
+        } else if vault_b_in.is_some() && vault_a_out.is_some() {
+            let b_in = vault_b_in.unwrap();
+            let a_out = vault_a_out.unwrap();
+            (
+                vault_b.to_string(),
+                b_in.0,
+                b_in.2,
+                vault_a.to_string(),
+                a_out.0,
+                a_out.2,
+            )
+        } else {
+            log::debug!(
+                "get_swap_amounts: no matching transfer pattern (vault_a_in={}, vault_a_out={}, vault_b_in={}, vault_b_out={})",
+                vault_a_in.is_some(), vault_a_out.is_some(), vault_b_in.is_some(), vault_b_out.is_some()
+            );
+            return None;
+        };
+
+    let sold_info = get_token_account_info(tx, &sold_vault)?;
+    let bought_info = get_token_account_info(tx, &bought_vault)?;
+
+    Some(SwapAmounts {
+        sold: TransferInfo {
+            mint: sold_mint,
+            vault: sold_vault,
+            amount: sold_amount,
+            decimals: sold_info.decimals,
+        },
+        bought: TransferInfo {
+            mint: bought_mint,
+            vault: bought_vault,
+            amount: bought_amount,
+            decimals: bought_info.decimals,
+        },
+    })
+}
+
+/// Get swap amounts where one side may be missing (for Obric V2 direct routing).
+pub fn get_swap_amounts_partial(
+    tx: &TransactionData,
+    outer_idx: usize,
+    _inner_idx: usize,
+    vault_a: &str,
+    vault_b: &str,
+    vault_a_info: &TokenAccountInfo,
+    vault_b_info: &TokenAccountInfo,
+) -> Option<PartialSwapAmounts> {
+    let transfers = extract_transfers(tx, outer_idx, None);
+
+    let mut sold: Option<TransferInfo> = None;
+    let mut bought: Option<TransferInfo> = None;
+
+    for t in &transfers {
+        // Transfer TO vault = user selling
+        if t.destination == vault_a && sold.is_none() {
+            sold = Some(TransferInfo {
+                mint: vault_a_info.mint.clone(),
+                vault: vault_a.to_string(),
+                amount: t.amount,
+                decimals: vault_a_info.decimals,
+            });
+        } else if t.destination == vault_b && sold.is_none() {
+            sold = Some(TransferInfo {
+                mint: vault_b_info.mint.clone(),
+                vault: vault_b.to_string(),
+                amount: t.amount,
+                decimals: vault_b_info.decimals,
+            });
+        }
+        // Transfer FROM vault = user buying
+        if t.source == vault_a && bought.is_none() {
+            bought = Some(TransferInfo {
+                mint: vault_a_info.mint.clone(),
+                vault: vault_a.to_string(),
+                amount: t.amount,
+                decimals: vault_a_info.decimals,
+            });
+        } else if t.source == vault_b && bought.is_none() {
+            bought = Some(TransferInfo {
+                mint: vault_b_info.mint.clone(),
+                vault: vault_b.to_string(),
+                amount: t.amount,
+                decimals: vault_b_info.decimals,
+            });
+        }
+    }
+
+    if sold.is_none() && bought.is_none() {
+        return None;
+    }
+
+    Some(PartialSwapAmounts { sold, bought })
+}
+
+// Internal: raw transfer parsed from inner instructions
+#[derive(Debug)]
+struct RawTransfer {
+    source: String,
+    destination: String,
+    amount: u64,
+    mint: String,
+}
+
+fn extract_transfers(
+    tx: &TransactionData,
+    outer_idx: usize,
+    exclude_accounts: Option<&[&str]>,
+) -> Vec<RawTransfer> {
+    let account_keys = get_all_account_keys(tx);
+    let inner_instructions = tx
+        .transaction_status_meta
+        .inner_instructions
+        .as_ref()
+        .unwrap_or(&Vec::new())
+        .clone();
+
+    // Find the inner instruction set matching this outer instruction (0-based index)
+    let inner_set = inner_instructions
+        .iter()
+        .find(|s| s.index as usize == outer_idx - 1); // outer_idx is 1-based
+
+    let inner_set = match inner_set {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+
+    let mut results = Vec::new();
+
+    for inner_ix in &inner_set.instructions {
+        let program_id = account_keys
+            .get(inner_ix.instruction.program_id_index as usize)
+            .map(|a| a.to_string())
+            .unwrap_or_default();
+
+        if program_id != SPL_TOKEN_PROGRAM && program_id != TOKEN_2022_PROGRAM {
+            continue;
+        }
+
+        let data = &inner_ix.instruction.data;
+        if data.is_empty() {
+            continue;
+        }
+
+        let (source_idx, dest_idx, amount) = match data[0] {
+            TRANSFER_DISCRIMINATOR if data.len() >= 9 => {
+                let accounts = &inner_ix.instruction.accounts;
+                if accounts.len() < 3 {
+                    continue;
+                }
+                let amount = u64::from_le_bytes(data[1..9].try_into().unwrap());
+                (accounts[0] as usize, accounts[1] as usize, amount)
+            }
+            TRANSFER_CHECKED_DISCRIMINATOR if data.len() >= 9 => {
+                let accounts = &inner_ix.instruction.accounts;
+                if accounts.len() < 4 {
+                    continue;
+                }
+                let amount = u64::from_le_bytes(data[1..9].try_into().unwrap());
+                (accounts[0] as usize, accounts[2] as usize, amount)
+            }
+            _ => continue,
+        };
+
+        let source = account_keys
+            .get(source_idx)
+            .map(|a| a.to_string())
+            .unwrap_or_default();
+        let destination = account_keys
+            .get(dest_idx)
+            .map(|a| a.to_string())
+            .unwrap_or_default();
+
+        if let Some(excluded) = exclude_accounts {
+            if excluded.contains(&source.as_str()) || excluded.contains(&destination.as_str()) {
+                continue;
+            }
+        }
+
+        // Resolve mint from token balances
+        let mint = resolve_mint_for_account(tx, &account_keys, source_idx)
+            .or_else(|| resolve_mint_for_account(tx, &account_keys, dest_idx))
+            .unwrap_or_default();
+
+        results.push(RawTransfer {
+            source,
+            destination,
+            amount,
+            mint,
+        });
+    }
+
+    results
+}
+
+fn resolve_mint_for_account(
+    tx: &TransactionData,
+    _account_keys: &[solana_address::Address],
+    account_index: usize,
+) -> Option<String> {
+    let empty: Vec<TransactionTokenBalance> = Vec::new();
+    let post = tx
+        .transaction_status_meta
+        .post_token_balances
+        .as_ref()
+        .unwrap_or(&empty);
+    let pre = tx
+        .transaction_status_meta
+        .pre_token_balances
+        .as_ref()
+        .unwrap_or(&empty);
+    let all_balances: Vec<&TransactionTokenBalance> = post.iter().chain(pre.iter()).collect();
+
+    all_balances
+        .iter()
+        .find(|b| b.account_index as usize == account_index)
+        .map(|b| b.mint.clone())
+}
+
+fn get_all_account_keys(tx: &TransactionData) -> Vec<solana_address::Address> {
+    use solana_message::VersionedMessage;
+    match &tx.transaction.message {
+        VersionedMessage::Legacy(msg) => msg.account_keys.clone(),
+        VersionedMessage::V0(msg) => {
+            let mut keys = msg.account_keys.clone();
+            let loaded = &tx.transaction_status_meta.loaded_addresses;
+            keys.extend_from_slice(&loaded.writable);
+            keys.extend_from_slice(&loaded.readonly);
+            keys
+        }
+    }
+}

--- a/jetstreamer-dex-trades/src/token_transfers.rs
+++ b/jetstreamer-dex-trades/src/token_transfers.rs
@@ -62,9 +62,7 @@ pub struct PartialSwapAmounts {
 /// Get token account info from pre/post token balances.
 pub fn get_token_account_info(tx: &TransactionData, account: &str) -> Option<TokenAccountInfo> {
     let account_keys = get_all_account_keys(tx);
-    let account_index = account_keys
-        .iter()
-        .position(|k| k.to_string() == account)?;
+    let account_index = account_keys.iter().position(|k| k.to_string() == account)?;
 
     let pre_balances = tx
         .transaction_status_meta
@@ -131,7 +129,7 @@ pub fn get_swap_amounts(
         if t.destination == vault_a {
             let entry = &mut vault_a_in;
             if take_largest {
-                if entry.as_ref().map_or(true, |e| t.amount > e.0) {
+                if entry.as_ref().is_none_or(|e| t.amount > e.0) {
                     *entry = Some((t.amount, t.source.clone(), t.mint.clone()));
                 }
             } else if entry.is_none() {
@@ -140,7 +138,7 @@ pub fn get_swap_amounts(
         } else if t.source == vault_a {
             let entry = &mut vault_a_out;
             if take_largest {
-                if entry.as_ref().map_or(true, |e| t.amount > e.0) {
+                if entry.as_ref().is_none_or(|e| t.amount > e.0) {
                     *entry = Some((t.amount, t.destination.clone(), t.mint.clone()));
                 }
             } else if entry.is_none() {
@@ -151,7 +149,7 @@ pub fn get_swap_amounts(
         if t.destination == vault_b {
             let entry = &mut vault_b_in;
             if take_largest {
-                if entry.as_ref().map_or(true, |e| t.amount > e.0) {
+                if entry.as_ref().is_none_or(|e| t.amount > e.0) {
                     *entry = Some((t.amount, t.source.clone(), t.mint.clone()));
                 }
             } else if entry.is_none() {
@@ -160,7 +158,7 @@ pub fn get_swap_amounts(
         } else if t.source == vault_b {
             let entry = &mut vault_b_out;
             if take_largest {
-                if entry.as_ref().map_or(true, |e| t.amount > e.0) {
+                if entry.as_ref().is_none_or(|e| t.amount > e.0) {
                     *entry = Some((t.amount, t.destination.clone(), t.mint.clone()));
                 }
             } else if entry.is_none() {
@@ -170,36 +168,39 @@ pub fn get_swap_amounts(
     }
 
     // Determine direction: user sends to one vault, receives from the other
-    let (sold_vault, sold_amount, sold_mint, bought_vault, bought_amount, bought_mint) =
-        if vault_a_in.is_some() && vault_b_out.is_some() {
-            let a_in = vault_a_in.unwrap();
-            let b_out = vault_b_out.unwrap();
-            (
-                vault_a.to_string(),
-                a_in.0,
-                a_in.2,
-                vault_b.to_string(),
-                b_out.0,
-                b_out.2,
-            )
-        } else if vault_b_in.is_some() && vault_a_out.is_some() {
-            let b_in = vault_b_in.unwrap();
-            let a_out = vault_a_out.unwrap();
-            (
-                vault_b.to_string(),
-                b_in.0,
-                b_in.2,
-                vault_a.to_string(),
-                a_out.0,
-                a_out.2,
-            )
-        } else {
+    let (sold_vault, sold_amount, sold_mint, bought_vault, bought_amount, bought_mint) = match (
+        &vault_a_in,
+        &vault_b_out,
+        &vault_b_in,
+        &vault_a_out,
+    ) {
+        (Some(a_in), Some(b_out), _, _) => (
+            vault_a.to_string(),
+            a_in.0,
+            a_in.2.clone(),
+            vault_b.to_string(),
+            b_out.0,
+            b_out.2.clone(),
+        ),
+        (_, _, Some(b_in), Some(a_out)) => (
+            vault_b.to_string(),
+            b_in.0,
+            b_in.2.clone(),
+            vault_a.to_string(),
+            a_out.0,
+            a_out.2.clone(),
+        ),
+        _ => {
             log::debug!(
                 "get_swap_amounts: no matching transfer pattern (vault_a_in={}, vault_a_out={}, vault_b_in={}, vault_b_out={})",
-                vault_a_in.is_some(), vault_a_out.is_some(), vault_b_in.is_some(), vault_b_out.is_some()
+                vault_a_in.is_some(),
+                vault_a_out.is_some(),
+                vault_b_in.is_some(),
+                vault_b_out.is_some()
             );
             return None;
-        };
+        }
+    };
 
     let sold_info = get_token_account_info(tx, &sold_vault)?;
     let bought_info = get_token_account_info(tx, &bought_vault)?;
@@ -355,10 +356,10 @@ fn extract_transfers(
             .map(|a| a.to_string())
             .unwrap_or_default();
 
-        if let Some(excluded) = exclude_accounts {
-            if excluded.contains(&source.as_str()) || excluded.contains(&destination.as_str()) {
-                continue;
-            }
+        if let Some(excluded) = exclude_accounts
+            && (excluded.contains(&source.as_str()) || excluded.contains(&destination.as_str()))
+        {
+            continue;
         }
 
         // Resolve mint from token balances

--- a/jetstreamer-dex-trades/src/transaction_ext.rs
+++ b/jetstreamer-dex-trades/src/transaction_ext.rs
@@ -1,0 +1,99 @@
+//! Extension methods on [`TransactionData`] for common queries.
+
+use jetstreamer_firehose::firehose::TransactionData;
+use solana_address::Address;
+use solana_message::VersionedMessage;
+
+pub trait TransactionExt {
+    fn is_successful(&self) -> bool;
+    fn is_failed(&self) -> bool;
+    fn is_vote_transaction(&self) -> bool;
+    fn account_keys(&self) -> Vec<Address>;
+    fn get_logs(&self) -> Vec<String>;
+    fn get_total_fee(&self) -> u64;
+    fn get_base_fee(&self) -> u64;
+    fn get_priority_fee(&self) -> u64;
+    fn get_jito_tips(&self) -> u64;
+}
+
+const JITO_TIP_ACCOUNTS: &[&str] = &[
+    "ADaUMid9yfUytqMBgopwjb2DTLSokTSzL1zt6iGPaS49",
+    "Cw8CFyM9FkoMi7K7Crf6HNQqf4uEMzpKw6QNghXLvLkY",
+    "HFqU5x63VTqvQss8hp11i4wVV8bD44PvwucfZ2bU7gRe",
+    "DfXygSm4jCyNCybVYYK6DwvWqjKee8pbDmJGcLWNDXjh",
+    "96gYZGLnJYVFmbjzopPSU6QiEV5fGqZNyN9nmNhvrZU5",
+    "ADuUkR4vqLUMWXxW9gh6D6L8pMSawimctcNZ5pGwDcEt",
+    "3AVi9Tg9Uo68tJfuvoKvqKNWKkC5wPdSSdeBnizKZ6jT",
+    "DttWaMuVvTiduZRnguLF7jNxTgiMBZ1hyAumKUiL2KRL",
+];
+
+impl TransactionExt for TransactionData {
+    fn is_successful(&self) -> bool {
+        self.transaction_status_meta.status.is_ok()
+    }
+
+    fn is_failed(&self) -> bool {
+        self.transaction_status_meta.status.is_err()
+    }
+
+    fn is_vote_transaction(&self) -> bool {
+        self.is_vote
+    }
+
+    fn account_keys(&self) -> Vec<Address> {
+        match &self.transaction.message {
+            VersionedMessage::Legacy(msg) => msg.account_keys.clone(),
+            VersionedMessage::V0(msg) => {
+                let mut keys = msg.account_keys.clone();
+                let loaded = &self.transaction_status_meta.loaded_addresses;
+                keys.extend_from_slice(&loaded.writable);
+                keys.extend_from_slice(&loaded.readonly);
+                keys
+            }
+        }
+    }
+
+    fn get_logs(&self) -> Vec<String> {
+        self.transaction_status_meta
+            .log_messages
+            .as_ref()
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn get_total_fee(&self) -> u64 {
+        self.transaction_status_meta.fee
+    }
+
+    fn get_base_fee(&self) -> u64 {
+        const LAMPORTS_PER_SIGNATURE: u64 = 5000;
+        let num_signatures = match &self.transaction.message {
+            VersionedMessage::Legacy(msg) => msg.header.num_required_signatures as u64,
+            VersionedMessage::V0(msg) => msg.header.num_required_signatures as u64,
+        };
+        num_signatures * LAMPORTS_PER_SIGNATURE
+    }
+
+    fn get_priority_fee(&self) -> u64 {
+        self.get_total_fee().saturating_sub(self.get_base_fee())
+    }
+
+    fn get_jito_tips(&self) -> u64 {
+        let account_keys = self.account_keys();
+        let pre_balances = &self.transaction_status_meta.pre_balances;
+        let post_balances = &self.transaction_status_meta.post_balances;
+
+        let mut total_tips: u64 = 0;
+        for (idx, account) in account_keys.iter().enumerate() {
+            let account_str = account.to_string();
+            if JITO_TIP_ACCOUNTS.contains(&account_str.as_str()) {
+                let pre = pre_balances.get(idx).copied().unwrap_or(0);
+                let post = post_balances.get(idx).copied().unwrap_or(0);
+                if post > pre {
+                    total_tips = total_tips.saturating_add(post - pre);
+                }
+            }
+        }
+        total_tips
+    }
+}

--- a/jetstreamer-dex-trades/src/types.rs
+++ b/jetstreamer-dex-trades/src/types.rs
@@ -249,10 +249,12 @@ mod tests {
     #[test]
     fn test_swap_record_validate_missing_pool_is_ok_for_poolless() {
         let mut record = sample_swap_record();
-        record.outer_program =
-            "AQU1FRd7papthgdrwPTTq5JacJh8YtwEXaBfKU3bTz45".to_string();
+        record.outer_program = "AQU1FRd7papthgdrwPTTq5JacJh8YtwEXaBfKU3bTz45".to_string();
         record.pool_address = String::new();
-        assert!(record.validate().is_ok(), "poolless programs should pass without pool_address");
+        assert!(
+            record.validate().is_ok(),
+            "poolless programs should pass without pool_address"
+        );
     }
 
     #[test]
@@ -266,7 +268,10 @@ mod tests {
         assert_eq!(proto.tx_id, record.tx_id);
         assert_eq!(proto.tx_index, record.tx_index);
         assert_eq!(proto.instruction_index, record.instruction_index);
-        assert_eq!(proto.inner_instruction_index, record.inner_instruction_index);
+        assert_eq!(
+            proto.inner_instruction_index,
+            record.inner_instruction_index
+        );
         assert_eq!(proto.is_inner_instruction, record.is_inner_instruction);
         assert_eq!(proto.instruction_type, record.instruction_type);
         assert_eq!(proto.outer_program, record.outer_program);
@@ -307,7 +312,10 @@ mod tests {
         let decoded = crate::proto::DexTradesBatch::decode(bytes.as_slice()).unwrap();
         assert_eq!(decoded.slot, 280_000_000);
         assert_eq!(decoded.records.len(), 1);
-        assert_eq!(decoded.records[0].tx_id, "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9Cos");
+        assert_eq!(
+            decoded.records[0].tx_id,
+            "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9Cos"
+        );
     }
 
     #[test]

--- a/jetstreamer-dex-trades/src/types.rs
+++ b/jetstreamer-dex-trades/src/types.rs
@@ -1,0 +1,324 @@
+//! Unified [`SwapRecord`] type for all DEX decoders.
+//!
+//! ## Token Convention
+//! - `token_bought` = token user RECEIVED (output of swap)
+//! - `token_sold`   = token user SENT (input to swap)
+
+use chrono::NaiveDate;
+
+/// Programs that don't have a pool address concept.
+const PROGRAMS_WITHOUT_POOL: &[&str] = &[
+    "AQU1FRd7papthgdrwPTTq5JacJh8YtwEXaBfKU3bTz45", // Aquifer
+];
+
+/// Unified swap record for all DEX protocols.
+#[derive(Debug, Clone)]
+pub struct SwapRecord {
+    // Block identity
+    pub block_slot: u64,
+    pub block_time: i64,
+    pub block_date: NaiveDate,
+
+    // Transaction identity
+    pub tx_id: String,
+    pub tx_index: u32,
+
+    // Instruction identity
+    pub instruction_index: u32,
+    pub inner_instruction_index: u32,
+    pub is_inner_instruction: bool,
+    pub instruction_type: String,
+
+    // Program identity
+    pub outer_program: String,
+    pub inner_program: String,
+
+    // Pool & signer
+    pub pool_address: String,
+    pub signer: String,
+
+    // Token bought (user received)
+    pub token_bought_mint: String,
+    pub token_bought_vault: String,
+    pub token_bought_amount: f64,
+    pub token_bought_decimals: u8,
+    pub token_bought_vault_reserve: f64,
+
+    // Token sold (user sent)
+    pub token_sold_mint: String,
+    pub token_sold_vault: String,
+    pub token_sold_amount: f64,
+    pub token_sold_decimals: u8,
+    pub token_sold_vault_reserve: f64,
+
+    // Fees (SOL)
+    pub txn_fee: f64,
+    pub priority_fee: f64,
+    pub jito_tips: f64,
+
+    // CLMM pool state
+    pub sqrt_price: String,
+    pub is_base_to_quote: Option<bool>,
+
+    // Compute
+    pub compute_units_consumed: u64,
+}
+
+impl Default for SwapRecord {
+    fn default() -> Self {
+        Self {
+            block_slot: 0,
+            block_time: 0,
+            block_date: NaiveDate::from_ymd_opt(1970, 1, 1).unwrap(),
+            tx_id: String::new(),
+            tx_index: 0,
+            instruction_index: 0,
+            inner_instruction_index: 0,
+            is_inner_instruction: false,
+            instruction_type: String::new(),
+            outer_program: String::new(),
+            inner_program: String::new(),
+            pool_address: String::new(),
+            signer: String::new(),
+            token_bought_mint: String::new(),
+            token_bought_vault: String::new(),
+            token_bought_amount: 0.0,
+            token_bought_decimals: 0,
+            token_bought_vault_reserve: 0.0,
+            token_sold_mint: String::new(),
+            token_sold_vault: String::new(),
+            token_sold_amount: 0.0,
+            token_sold_decimals: 0,
+            token_sold_vault_reserve: 0.0,
+            txn_fee: 0.0,
+            priority_fee: 0.0,
+            jito_tips: 0.0,
+            sqrt_price: String::new(),
+            is_base_to_quote: None,
+            compute_units_consumed: 0,
+        }
+    }
+}
+
+impl SwapRecord {
+    fn is_poolless_program(&self) -> bool {
+        PROGRAMS_WITHOUT_POOL.contains(&self.outer_program.as_str())
+            || PROGRAMS_WITHOUT_POOL.contains(&self.inner_program.as_str())
+    }
+
+    /// Validate that all mandatory fields are populated.
+    pub fn validate(&self) -> Result<(), String> {
+        let mandatory_fields = [
+            ("tx_id", &self.tx_id),
+            ("signer", &self.signer),
+            ("pool_address", &self.pool_address),
+            ("token_bought_mint", &self.token_bought_mint),
+            ("token_bought_vault", &self.token_bought_vault),
+            ("token_sold_mint", &self.token_sold_mint),
+            ("token_sold_vault", &self.token_sold_vault),
+            ("outer_program", &self.outer_program),
+            ("instruction_type", &self.instruction_type),
+        ];
+
+        let is_poolless = self.is_poolless_program();
+
+        for (field_name, value) in mandatory_fields {
+            if field_name == "pool_address" && is_poolless {
+                continue;
+            }
+            if value.is_empty() {
+                return Err(format!(
+                    "empty mandatory field '{}' in SwapRecord (tx_id={}, outer_program={})",
+                    field_name,
+                    if self.tx_id.is_empty() {
+                        "EMPTY"
+                    } else {
+                        &self.tx_id
+                    },
+                    if self.outer_program.is_empty() {
+                        "EMPTY"
+                    } else {
+                        &self.outer_program
+                    },
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Convert to protobuf representation.
+    pub fn to_proto(&self) -> crate::proto::SwapRecord {
+        crate::proto::SwapRecord {
+            block_slot: self.block_slot,
+            block_time: self.block_time,
+            block_date: self.block_date.format("%Y-%m-%d").to_string(),
+            tx_id: self.tx_id.clone(),
+            tx_index: self.tx_index,
+            instruction_index: self.instruction_index,
+            inner_instruction_index: self.inner_instruction_index,
+            is_inner_instruction: self.is_inner_instruction,
+            instruction_type: self.instruction_type.clone(),
+            outer_program: self.outer_program.clone(),
+            inner_program: self.inner_program.clone(),
+            pool_address: self.pool_address.clone(),
+            signer: self.signer.clone(),
+            token_bought_mint: self.token_bought_mint.clone(),
+            token_bought_vault: self.token_bought_vault.clone(),
+            token_bought_amount: self.token_bought_amount,
+            token_bought_decimals: self.token_bought_decimals as u32,
+            token_bought_vault_reserve: self.token_bought_vault_reserve,
+            token_sold_mint: self.token_sold_mint.clone(),
+            token_sold_vault: self.token_sold_vault.clone(),
+            token_sold_amount: self.token_sold_amount,
+            token_sold_vault_reserve: self.token_sold_vault_reserve,
+            token_sold_decimals: self.token_sold_decimals as u32,
+            txn_fee: self.txn_fee,
+            priority_fee: self.priority_fee,
+            jito_tips: self.jito_tips,
+            sqrt_price: self.sqrt_price.clone(),
+            has_direction: self.is_base_to_quote.is_some(),
+            is_base_to_quote: self.is_base_to_quote.unwrap_or(false),
+            compute_units_consumed: self.compute_units_consumed,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use prost::Message;
+
+    fn sample_swap_record() -> SwapRecord {
+        SwapRecord {
+            block_slot: 280_000_000,
+            block_time: 1711000000,
+            block_date: NaiveDate::from_ymd_opt(2024, 3, 21).unwrap(),
+            tx_id: "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9Cos".to_string(),
+            tx_index: 42,
+            instruction_index: 1,
+            inner_instruction_index: 2,
+            is_inner_instruction: true,
+            instruction_type: "swap".to_string(),
+            outer_program: "675kPX9MHTjS2zt1qfr1NYHuzeLXfQM9H24wFSUt1Mp8".to_string(),
+            inner_program: "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA".to_string(),
+            pool_address: "58oQChx4yWmvKdwLLZzBi4ChoCc2fqCUWBkwMihLYQo2".to_string(),
+            signer: "FmKAfMMnxRMaqG7yWrLMyLLEcRPQFqBPHH9Pmosigner".to_string(),
+            token_bought_mint: "So11111111111111111111111111111111111111112".to_string(),
+            token_bought_vault: "HWy1jotHpo6UqeQCR5m3bCA9PUbNK6a6".to_string(),
+            token_bought_amount: 1.5,
+            token_bought_decimals: 9,
+            token_bought_vault_reserve: 100.0,
+            token_sold_mint: "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v".to_string(),
+            token_sold_vault: "ErcxwkPgL2Sc8qFNmY7Go".to_string(),
+            token_sold_amount: 250.0,
+            token_sold_decimals: 6,
+            token_sold_vault_reserve: 5000.0,
+            txn_fee: 0.000005,
+            priority_fee: 0.001,
+            jito_tips: 0.0,
+            sqrt_price: String::new(),
+            is_base_to_quote: None,
+            compute_units_consumed: 200_000,
+        }
+    }
+
+    #[test]
+    fn test_swap_record_default() {
+        let record = SwapRecord::default();
+        assert_eq!(record.block_slot, 0);
+        assert_eq!(record.tx_id, "");
+        assert_eq!(
+            record.block_date,
+            NaiveDate::from_ymd_opt(1970, 1, 1).unwrap()
+        );
+    }
+
+    #[test]
+    fn test_swap_record_validate_success() {
+        let record = sample_swap_record();
+        assert!(record.validate().is_ok());
+    }
+
+    #[test]
+    fn test_swap_record_validate_missing_tx_id() {
+        let mut record = sample_swap_record();
+        record.tx_id = String::new();
+        assert!(record.validate().is_err());
+    }
+
+    #[test]
+    fn test_swap_record_validate_missing_pool_is_ok_for_poolless() {
+        let mut record = sample_swap_record();
+        record.outer_program =
+            "AQU1FRd7papthgdrwPTTq5JacJh8YtwEXaBfKU3bTz45".to_string();
+        record.pool_address = String::new();
+        assert!(record.validate().is_ok(), "poolless programs should pass without pool_address");
+    }
+
+    #[test]
+    fn test_swap_record_to_proto_roundtrip() {
+        let record = sample_swap_record();
+        let proto = record.to_proto();
+
+        assert_eq!(proto.block_slot, record.block_slot);
+        assert_eq!(proto.block_time, record.block_time);
+        assert_eq!(proto.block_date, "2024-03-21");
+        assert_eq!(proto.tx_id, record.tx_id);
+        assert_eq!(proto.tx_index, record.tx_index);
+        assert_eq!(proto.instruction_index, record.instruction_index);
+        assert_eq!(proto.inner_instruction_index, record.inner_instruction_index);
+        assert_eq!(proto.is_inner_instruction, record.is_inner_instruction);
+        assert_eq!(proto.instruction_type, record.instruction_type);
+        assert_eq!(proto.outer_program, record.outer_program);
+        assert_eq!(proto.inner_program, record.inner_program);
+        assert_eq!(proto.pool_address, record.pool_address);
+        assert_eq!(proto.signer, record.signer);
+        assert_eq!(proto.token_bought_mint, record.token_bought_mint);
+        assert_eq!(proto.token_bought_amount, record.token_bought_amount);
+        assert_eq!(proto.token_sold_mint, record.token_sold_mint);
+        assert_eq!(proto.token_sold_amount, record.token_sold_amount);
+        assert_eq!(proto.txn_fee, record.txn_fee);
+        assert_eq!(proto.priority_fee, record.priority_fee);
+        assert_eq!(proto.jito_tips, record.jito_tips);
+        assert!(!proto.has_direction);
+        assert!(!proto.is_base_to_quote);
+        assert_eq!(proto.compute_units_consumed, record.compute_units_consumed);
+
+        let bytes = proto.encode_to_vec();
+        assert!(!bytes.is_empty());
+
+        let decoded = crate::proto::SwapRecord::decode(bytes.as_slice()).unwrap();
+        assert_eq!(decoded.tx_id, record.tx_id);
+        assert_eq!(decoded.block_slot, record.block_slot);
+        assert_eq!(decoded.token_bought_amount, record.token_bought_amount);
+        assert_eq!(decoded.token_sold_amount, record.token_sold_amount);
+    }
+
+    #[test]
+    fn test_proto_batch_roundtrip() {
+        let record = sample_swap_record();
+        let batch = crate::proto::DexTradesBatch {
+            slot: 280_000_000,
+            block_time: 1711000000,
+            records: vec![record.to_proto()],
+        };
+
+        let bytes = batch.encode_to_vec();
+        let decoded = crate::proto::DexTradesBatch::decode(bytes.as_slice()).unwrap();
+        assert_eq!(decoded.slot, 280_000_000);
+        assert_eq!(decoded.records.len(), 1);
+        assert_eq!(decoded.records[0].tx_id, "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9Cos");
+    }
+
+    #[test]
+    fn test_clmm_direction_fields() {
+        let mut record = sample_swap_record();
+        record.sqrt_price = "79228162514264337593543950336".to_string();
+        record.is_base_to_quote = Some(true);
+
+        let proto = record.to_proto();
+        assert!(proto.has_direction);
+        assert!(proto.is_base_to_quote);
+        assert_eq!(proto.sqrt_price, "79228162514264337593543950336");
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,10 +120,10 @@
 //! Epochs at or above `157` work with the bundled Geyser plugin interface, while compute unit
 //! accounting first appears at epoch `450`.
 
+pub use jetstreamer_dex_trades as dex_trades;
 pub use jetstreamer_firehose as firehose;
 pub use jetstreamer_plugin as plugin;
 pub use jetstreamer_utils as utils;
-pub use jetstreamer_dex_trades as dex_trades;
 
 use core::ops::Range;
 use jetstreamer_firehose::{epochs::slot_to_epoch, index::get_index_base_url};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -123,6 +123,7 @@
 pub use jetstreamer_firehose as firehose;
 pub use jetstreamer_plugin as plugin;
 pub use jetstreamer_utils as utils;
+pub use jetstreamer_dex_trades as dex_trades;
 
 use core::ops::Range;
 use jetstreamer_firehose::{epochs::slot_to_epoch, index::get_index_base_url};
@@ -569,6 +570,8 @@ pub enum BuiltinPlugin {
     ProgramTracking,
     /// Instruction Tracking.
     InstructionTracking,
+    /// DEX Trades — decodes swaps from 28+ Solana DEX programs.
+    DexTrades,
 }
 
 impl BuiltinPlugin {
@@ -576,6 +579,7 @@ impl BuiltinPlugin {
         match value {
             "program-tracking" => Some(Self::ProgramTracking),
             "instruction-tracking" => Some(Self::InstructionTracking),
+            "dex-trades" => Some(Self::DexTrades),
             _ => None,
         }
     }
@@ -584,6 +588,7 @@ impl BuiltinPlugin {
         match self {
             Self::ProgramTracking => Box::new(ProgramTrackingPlugin::new()),
             Self::InstructionTracking => Box::new(InstructionTrackingPlugin::new()),
+            Self::DexTrades => Box::new(jetstreamer_dex_trades::DexTradesPlugin::new()),
         }
     }
 }
@@ -632,7 +637,7 @@ pub fn parse_cli_args() -> Result<Config, Box<dyn std::error::Error>> {
                     .ok_or_else(|| "--with-plugin requires a plugin name".to_string())?;
                 let plugin = BuiltinPlugin::from_flag(&plugin_name).ok_or_else(|| {
                     format!(
-                        "unknown plugin '{plugin_name}'. expected 'program-tracking' or 'instruction-tracking'"
+                        "unknown plugin '{plugin_name}'. expected 'program-tracking', 'instruction-tracking', or 'dex-trades'"
                     )
                 })?;
                 builtin_plugins.push(plugin);


### PR DESCRIPTION
… DEX programs

Adds a new `jetstreamer-dex-trades` workspace crate that decodes swap transactions from 30 Solana DEX programs into a unified protobuf SwapRecord format.

Supported DEXes: Pump Fun, Pump AMM, Raydium (AMM V4, CPMM, CLMM, LaunchLab), Orca (V2, Whirlpool), Meteora (DAMM V2, DBC, DLMM, Pools), Manifest, Aquifer, Lifinity V1/V2, PancakeSwap CLMM, Byreal CLMM, Futarchy AMM, Obric V2, SolFi V1/V2, AlphaQ, BisonFi, ZeroFi, GoonFi, HumidiFi, Tessera, Stabble Stable/Weighted.

Usage: cargo run --release -- --with-plugin dex-trades <slot-range>

Contributed by Top Ledger (https://topledger.xyz/)

Made-with: Cursor