### PR TITLE
pubkey stats plugin + performance regression fix + performance improvement - 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3854,7 +3854,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jetstreamer"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clickhouse",
  "jetstreamer-firehose",
@@ -3872,7 +3872,7 @@ dependencies = [
 
 [[package]]
 name = "jetstreamer-firehose"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash 0.8.12",
  "aws-credential-types",
@@ -3925,7 +3925,7 @@ dependencies = [
 
 [[package]]
 name = "jetstreamer-plugin"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ahash 0.8.12",
  "clickhouse",
@@ -3946,7 +3946,7 @@ dependencies = [
 
 [[package]]
 name = "jetstreamer-utils"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "ctrlc",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3874,6 +3874,7 @@ dependencies = [
 name = "jetstreamer-firehose"
 version = "0.5.0"
 dependencies = [
+ "ahash 0.8.12",
  "aws-credential-types",
  "aws-sdk-s3",
  "aws-smithy-types",
@@ -3926,6 +3927,7 @@ dependencies = [
 name = "jetstreamer-plugin"
 version = "0.5.0"
 dependencies = [
+ "ahash 0.8.12",
  "clickhouse",
  "dashmap",
  "futures-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["jetstreamer-firehose", "jetstreamer-plugin", "jetstreamer-utils"]
 
 [workspace.package]
 edition = "2024"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["sam0x17", "anza-team"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/anza-xyz/jetstreamer"
@@ -27,9 +27,9 @@ s3-backend = ["jetstreamer-firehose/s3-backend"]
 verify-transaction-signatures = ["jetstreamer-firehose/verify-transaction-signatures"]
 
 [workspace.dependencies]
-jetstreamer-firehose = { path = "jetstreamer-firehose", version = "0.5.0" }
-jetstreamer-plugin = { path = "jetstreamer-plugin", version = "0.5.0" }
-jetstreamer-utils = { path = "jetstreamer-utils", version = "0.5.0" }
+jetstreamer-firehose = { path = "jetstreamer-firehose", version = "0.5.1" }
+jetstreamer-plugin = { path = "jetstreamer-plugin", version = "0.5.1" }
+jetstreamer-utils = { path = "jetstreamer-utils", version = "0.5.1" }
 tokio = "1"
 futures-util = { version = "0", default-features = false }
 futures = "0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ rseek = ">= 0.2"
 ripget = "0.2"
 rayon = "1"
 xxhash-rust = { version = "0.8", features = ["xxh64"] }
+ahash = "0.8"
 dashmap = "5"
 clickhouse = { version = "0.14", default-features = false }
 interprocess = { version = "2", features = ["tokio"] }

--- a/jetstreamer-firehose/Cargo.toml
+++ b/jetstreamer-firehose/Cargo.toml
@@ -41,7 +41,7 @@ solana-signature.workspace = true
 solana-sdk-ids.workspace = true
 prost_011.workspace = true
 solana-entry.workspace = true
-reqwest = { workspace = true, features = ["rustls-tls", "stream"] }
+reqwest = { workspace = true, features = ["stream"] }
 tokio.workspace = true
 futures-util.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/jetstreamer-firehose/Cargo.toml
+++ b/jetstreamer-firehose/Cargo.toml
@@ -62,6 +62,7 @@ zstd.workspace = true
 solana-reward-info.workspace = true
 bincode.workspace = true
 xxhash-rust.workspace = true
+ahash.workspace = true
 dashmap.workspace = true
 once_cell.workspace = true
 url.workspace = true

--- a/jetstreamer-firehose/src/firehose.rs
+++ b/jetstreamer-firehose/src/firehose.rs
@@ -387,7 +387,11 @@ fn fetch_add_if(tracking_enabled: bool, atomic: &AtomicU64, value: u64) {
     }
 }
 
-fn clear_pending_skip(map: &DashMap<usize, DashSet<u64>>, thread_id: usize, slot: u64) -> bool {
+fn clear_pending_skip(
+    map: &DashMap<usize, DashSet<u64, ahash::RandomState>, ahash::RandomState>,
+    thread_id: usize,
+    slot: u64,
+) -> bool {
     map.get(&thread_id)
         .map(|set| set.remove(&slot).is_some())
         .unwrap_or(false)
@@ -929,7 +933,9 @@ where
     let overall_blocks_processed: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
     let overall_transactions_processed: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
     let overall_entries_processed: Arc<AtomicU64> = Arc::new(AtomicU64::new(0));
-    let pending_skipped_slots: Arc<DashMap<usize, DashSet<u64>>> = Arc::new(DashMap::new());
+    let pending_skipped_slots: Arc<
+        DashMap<usize, DashSet<u64, ahash::RandomState>, ahash::RandomState>,
+    > = Arc::new(DashMap::with_hasher(ahash::RandomState::new()));
 
     for (thread_index, mut slot_range) in subranges.into_iter().enumerate() {
         let error_counts = error_counts.clone();
@@ -980,7 +986,9 @@ where
             let reward_enabled = on_reward.is_some();
             let tracking_enabled = stats_tracking.is_some();
             if block_enabled {
-                pending_skipped_slots.entry(thread_index).or_default();
+                pending_skipped_slots
+                    .entry(thread_index)
+                    .or_insert_with(|| DashSet::with_hasher(ahash::RandomState::new()));
             }
             let mut last_counted_slot = slot_range.start.saturating_sub(1);
             let mut last_emitted_slot_global = slot_range.start.saturating_sub(1);

--- a/jetstreamer-firehose/src/index.rs
+++ b/jetstreamer-firehose/src/index.rs
@@ -175,8 +175,10 @@ pub static SLOT_OFFSET_INDEX: Lazy<SlotOffsetIndex> = Lazy::new(|| {
 
 static START_INSTANT: Lazy<Instant> = Lazy::new(Instant::now);
 static LAST_HIT_TIME: AtomicU64 = AtomicU64::new(0);
-static SLOT_OFFSET_RESULT_CACHE: Lazy<DashMap<u64, u64>> = Lazy::new(DashMap::new);
-static EPOCH_CACHE: Lazy<DashMap<EpochCacheKey, Arc<EpochEntry>>> = Lazy::new(DashMap::new);
+static SLOT_OFFSET_RESULT_CACHE: Lazy<DashMap<u64, u64, ahash::RandomState>> =
+    Lazy::new(|| DashMap::with_hasher(ahash::RandomState::new()));
+static EPOCH_CACHE: Lazy<DashMap<EpochCacheKey, Arc<EpochEntry>, ahash::RandomState>> =
+    Lazy::new(|| DashMap::with_hasher(ahash::RandomState::new()));
 
 #[derive(Clone, Hash, PartialEq, Eq)]
 struct EpochCacheKey {
@@ -388,7 +390,7 @@ impl SlotOffsetIndex {
 struct EpochIndexes {
     slot_index: Arc<SlotCidIndex>,
     cid_index: Arc<CidOffsetIndex>,
-    slot_cid_cache: DashMap<u64, Arc<[u8]>>,
+    slot_cid_cache: DashMap<u64, Arc<[u8]>, ahash::RandomState>,
     slot_range: RangeInclusive<u64>,
 }
 
@@ -402,7 +404,7 @@ impl EpochIndexes {
         Self {
             slot_index: Arc::new(slot_index),
             cid_index: Arc::new(cid_index),
-            slot_cid_cache: DashMap::new(),
+            slot_cid_cache: DashMap::with_hasher(ahash::RandomState::new()),
             slot_range: slot_start..=slot_end_inclusive,
         }
     }
@@ -511,7 +513,7 @@ impl RemoteIndexFile {
 struct SlotCidIndex {
     file: Arc<RemoteIndexFile>,
     header: CompactIndexHeader,
-    bucket_entries: DashMap<u32, Arc<SlotBucketEntry>>,
+    bucket_entries: DashMap<u32, Arc<SlotBucketEntry>, ahash::RandomState>,
 }
 
 impl SlotCidIndex {
@@ -545,7 +547,7 @@ impl SlotCidIndex {
         Ok(Self {
             file,
             header,
-            bucket_entries: DashMap::new(),
+            bucket_entries: DashMap::with_hasher(ahash::RandomState::new()),
         })
     }
 
@@ -629,7 +631,7 @@ impl SlotCidIndex {
 struct CidOffsetIndex {
     object: RemoteObject,
     header: CompactIndexHeader,
-    bucket_entries: DashMap<u32, Arc<RemoteBucketEntry>>,
+    bucket_entries: DashMap<u32, Arc<RemoteBucketEntry>, ahash::RandomState>,
 }
 
 impl CidOffsetIndex {
@@ -663,7 +665,7 @@ impl CidOffsetIndex {
         Ok(Self {
             object,
             header,
-            bucket_entries: DashMap::new(),
+            bucket_entries: DashMap::with_hasher(ahash::RandomState::new()),
         })
     }
 

--- a/jetstreamer-firehose/src/network.rs
+++ b/jetstreamer-firehose/src/network.rs
@@ -16,8 +16,6 @@ pub fn create_http_client() -> Client {
     let user_agent = format!("jetstreamer/v{}", version);
     Client::builder()
         .user_agent(user_agent)
-        // Prefer rustls even when other workspace dependencies enable native-tls.
-        .use_rustls_tls()
         .build()
         .expect("failed to create HTTP client")
 }

--- a/jetstreamer-firehose/src/node.rs
+++ b/jetstreamer-firehose/src/node.rs
@@ -1,5 +1,6 @@
 use {
     crate::{SharedError, block, dataframe, entry, epoch, rewards, subset, transaction, utils},
+    ahash::RandomState,
     cid::Cid,
     core::hash::Hasher,
     crc::{CRC_64_GO_ISO, Crc},
@@ -40,13 +41,13 @@ impl NodeWithCid {
 pub struct NodesWithCids(
     #[doc = "Ordered collection of nodes paired with their content identifiers."]
     pub  Vec<NodeWithCid>,
-    #[doc(hidden)] HashMap<Cid, usize>,
+    #[doc(hidden)] HashMap<Cid, usize, RandomState>,
 );
 
 impl NodesWithCids {
     /// Creates an empty [`NodesWithCids`].
     pub fn new() -> NodesWithCids {
-        NodesWithCids(vec![], HashMap::new())
+        NodesWithCids(vec![], HashMap::with_hasher(RandomState::new()))
     }
 
     /// Appends a node to the collection.

--- a/jetstreamer-plugin/Cargo.toml
+++ b/jetstreamer-plugin/Cargo.toml
@@ -21,6 +21,7 @@ clickhouse.workspace = true
 futures-util.workspace = true
 thiserror.workspace = true
 sha2.workspace = true
+ahash.workspace = true
 dashmap.workspace = true
 once_cell.workspace = true
 solana-sdk-ids.workspace = true

--- a/jetstreamer-plugin/src/lib.rs
+++ b/jetstreamer-plugin/src/lib.rs
@@ -328,7 +328,8 @@ impl PluginRunner {
         }
 
         let shutting_down = Arc::new(AtomicBool::new(false));
-        let slot_buffer: Arc<DashMap<u16, Vec<PluginSlotRow>>> = Arc::new(DashMap::new());
+        let slot_buffer: Arc<DashMap<u16, Vec<PluginSlotRow>, ahash::RandomState>> =
+            Arc::new(DashMap::with_hasher(ahash::RandomState::new()));
         let clickhouse_enabled = clickhouse.is_some();
         let slots_since_flush = Arc::new(AtomicU64::new(0));
 
@@ -634,7 +635,7 @@ impl PluginRunner {
         LAST_TOTAL_TIME_NS.store(monotonic_nanos_since(run_origin), Ordering::Relaxed);
         let stats_tracking = clickhouse.clone().map(|_db| {
             let shutting_down = shutting_down.clone();
-            let thread_progress_max: Arc<DashMap<usize, f64>> = Arc::new(DashMap::new());
+            let thread_progress_max: Arc<DashMap<usize, f64, ahash::RandomState>> = Arc::new(DashMap::with_hasher(ahash::RandomState::new()));
             StatsTracking {
         on_stats: {
             let thread_progress_max = thread_progress_max.clone();
@@ -932,7 +933,8 @@ struct SlotTxTally {
     non_votes: u64,
 }
 
-static SLOT_TX_TALLY: Lazy<DashMap<u64, SlotTxTally>> = Lazy::new(DashMap::new);
+static SLOT_TX_TALLY: Lazy<DashMap<u64, SlotTxTally, ahash::RandomState>> =
+    Lazy::new(|| DashMap::with_hasher(ahash::RandomState::new()));
 
 async fn ensure_clickhouse_tables(db: &Client) -> Result<(), clickhouse::error::Error> {
     db.query(
@@ -1016,7 +1018,7 @@ async fn record_plugin_slot(
 
 async fn flush_slot_buffer(
     db: Arc<Client>,
-    buffer: Arc<DashMap<u16, Vec<PluginSlotRow>>>,
+    buffer: Arc<DashMap<u16, Vec<PluginSlotRow>, ahash::RandomState>>,
 ) -> Result<(), clickhouse::error::Error> {
     let mut rows = Vec::new();
     buffer.iter_mut().for_each(|mut entry| {

--- a/jetstreamer-plugin/src/plugins.rs
+++ b/jetstreamer-plugin/src/plugins.rs
@@ -2,3 +2,5 @@
 pub mod instruction_tracking;
 /// Default plugin that aggregates program invocation statistics.
 pub mod program_tracking;
+/// Plugin that tracks per-slot pubkey mention counts for popularity analysis.
+pub mod pubkey_stats;

--- a/jetstreamer-plugin/src/plugins/instruction_tracking.rs
+++ b/jetstreamer-plugin/src/plugins/instruction_tracking.rs
@@ -11,7 +11,8 @@ use solana_sdk_ids::vote::id as vote_program_id;
 use crate::{Plugin, PluginFuture};
 use jetstreamer_firehose::firehose::{BlockData, TransactionData};
 
-static PENDING_BY_SLOT: Lazy<DashMap<u64, SlotInstructionEvent>> = Lazy::new(DashMap::new);
+static PENDING_BY_SLOT: Lazy<DashMap<u64, SlotInstructionEvent, ahash::RandomState>> =
+    Lazy::new(|| DashMap::with_hasher(ahash::RandomState::new()));
 
 #[derive(Row, Deserialize, Serialize, Copy, Clone, Debug)]
 struct SlotInstructionEvent {

--- a/jetstreamer-plugin/src/plugins/program_tracking.rs
+++ b/jetstreamer-plugin/src/plugins/program_tracking.rs
@@ -1,3 +1,4 @@
+use ahash::RandomState;
 use std::{collections::HashMap, sync::Arc};
 
 use clickhouse::{Client, Row};
@@ -12,9 +13,10 @@ use crate::{Plugin, PluginFuture};
 use jetstreamer_firehose::firehose::{BlockData, TransactionData};
 
 type SlotProgramKey = (Address, bool);
-type SlotProgramEvents = HashMap<SlotProgramKey, ProgramEvent>;
+type SlotProgramEvents = HashMap<SlotProgramKey, ProgramEvent, RandomState>;
 
-static PENDING_BY_SLOT: Lazy<DashMap<u64, SlotProgramEvents>> = Lazy::new(DashMap::new);
+static PENDING_BY_SLOT: Lazy<DashMap<u64, SlotProgramEvents, RandomState>> =
+    Lazy::new(|| DashMap::with_hasher(RandomState::new()));
 
 #[derive(Row, Deserialize, Serialize, Copy, Clone, Debug, PartialEq, Eq, Hash)]
 struct ProgramEvent {
@@ -115,7 +117,9 @@ impl Plugin for ProgramTrackingPlugin {
             let slot = transaction.slot;
             let is_vote = transaction.is_vote;
 
-            let mut slot_entry = PENDING_BY_SLOT.entry(slot).or_default();
+            let mut slot_entry = PENDING_BY_SLOT
+                .entry(slot)
+                .or_insert_with(|| HashMap::with_hasher(RandomState::new()));
             for program_id in program_ids.iter() {
                 let this_program_cu = if program_count == 0 {
                     0

--- a/jetstreamer-plugin/src/plugins/pubkey_stats.rs
+++ b/jetstreamer-plugin/src/plugins/pubkey_stats.rs
@@ -12,7 +12,9 @@ use crate::{Plugin, PluginFuture};
 use jetstreamer_firehose::firehose::{BlockData, TransactionData};
 
 /// Per-slot accumulator: maps each pubkey to its mention count within that slot.
-static PENDING_BY_SLOT: Lazy<DashMap<u64, DashMap<Address, u32>>> = Lazy::new(DashMap::new);
+static PENDING_BY_SLOT: Lazy<
+    DashMap<u64, DashMap<Address, u32, ahash::RandomState>, ahash::RandomState>,
+> = Lazy::new(|| DashMap::with_hasher(ahash::RandomState::new()));
 
 #[derive(Row, Deserialize, Serialize, Copy, Clone, Debug)]
 struct PubkeyMention {
@@ -104,7 +106,9 @@ impl Plugin for PubkeyStatsPlugin {
             }
 
             let slot = transaction.slot;
-            let slot_entry = PENDING_BY_SLOT.entry(slot).or_default();
+            let slot_entry = PENDING_BY_SLOT
+                .entry(slot)
+                .or_insert_with(|| DashMap::with_hasher(ahash::RandomState::new()));
             for pubkey in account_keys {
                 *slot_entry.entry(*pubkey).or_insert(0) += 1;
             }

--- a/jetstreamer-plugin/src/plugins/pubkey_stats.rs
+++ b/jetstreamer-plugin/src/plugins/pubkey_stats.rs
@@ -1,0 +1,277 @@
+use std::sync::Arc;
+
+use clickhouse::{Client, Row};
+use dashmap::DashMap;
+use futures_util::FutureExt;
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use solana_address::Address;
+use solana_message::VersionedMessage;
+
+use crate::{Plugin, PluginFuture};
+use jetstreamer_firehose::firehose::{BlockData, TransactionData};
+
+/// Per-slot accumulator: maps each pubkey to its mention count within that slot.
+static PENDING_BY_SLOT: Lazy<DashMap<u64, DashMap<Address, u32>>> = Lazy::new(DashMap::new);
+
+#[derive(Row, Deserialize, Serialize, Copy, Clone, Debug)]
+struct PubkeyMention {
+    slot: u32,
+    timestamp: u32,
+    pubkey: Address,
+    num_mentions: u32,
+}
+
+#[derive(Debug, Clone)]
+/// Tracks per-slot pubkey mention counts and writes them to ClickHouse.
+///
+/// For every transaction, all account keys referenced in the message (both static and loaded)
+/// are counted. A ClickHouse `pubkey_mentions` table stores the aggregated count per
+/// `(slot, pubkey)` pair using `ReplacingMergeTree` for safe parallel ingestion.
+///
+/// A companion `pubkeys` table assigns a unique auto-incremented id to each pubkey, maintained
+/// via a materialised view so lookups by id are efficient.
+pub struct PubkeyStatsPlugin;
+
+impl PubkeyStatsPlugin {
+    /// Creates a new instance.
+    pub const fn new() -> Self {
+        Self
+    }
+
+    fn take_slot_events(slot: u64, block_time: Option<i64>) -> Vec<PubkeyMention> {
+        let timestamp = clamp_block_time(block_time);
+        if let Some((_, pubkey_counts)) = PENDING_BY_SLOT.remove(&slot) {
+            return pubkey_counts
+                .into_iter()
+                .map(|(pubkey, num_mentions)| PubkeyMention {
+                    slot: slot.min(u32::MAX as u64) as u32,
+                    timestamp,
+                    pubkey,
+                    num_mentions,
+                })
+                .collect();
+        }
+        Vec::new()
+    }
+
+    fn drain_all_pending(block_time: Option<i64>) -> Vec<PubkeyMention> {
+        let timestamp = clamp_block_time(block_time);
+        let slots: Vec<u64> = PENDING_BY_SLOT.iter().map(|entry| *entry.key()).collect();
+        let mut rows = Vec::new();
+        for slot in slots {
+            if let Some((_, pubkey_counts)) = PENDING_BY_SLOT.remove(&slot) {
+                rows.extend(pubkey_counts.into_iter().map(|(pubkey, num_mentions)| {
+                    PubkeyMention {
+                        slot: slot.min(u32::MAX as u64) as u32,
+                        timestamp,
+                        pubkey,
+                        num_mentions,
+                    }
+                }));
+            }
+        }
+        rows
+    }
+}
+
+impl Default for PubkeyStatsPlugin {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Plugin for PubkeyStatsPlugin {
+    #[inline(always)]
+    fn name(&self) -> &'static str {
+        "Pubkey Stats"
+    }
+
+    #[inline(always)]
+    fn on_transaction<'a>(
+        &'a self,
+        _thread_id: usize,
+        _db: Option<Arc<Client>>,
+        transaction: &'a TransactionData,
+    ) -> PluginFuture<'a> {
+        async move {
+            let account_keys = match &transaction.transaction.message {
+                VersionedMessage::Legacy(msg) => &msg.account_keys,
+                VersionedMessage::V0(msg) => &msg.account_keys,
+            };
+            if account_keys.is_empty() {
+                return Ok(());
+            }
+
+            let slot = transaction.slot;
+            let slot_entry = PENDING_BY_SLOT.entry(slot).or_default();
+            for pubkey in account_keys {
+                *slot_entry.entry(*pubkey).or_insert(0) += 1;
+            }
+
+            Ok(())
+        }
+        .boxed()
+    }
+
+    #[inline(always)]
+    fn on_block(
+        &self,
+        _thread_id: usize,
+        db: Option<Arc<Client>>,
+        block: &BlockData,
+    ) -> PluginFuture<'_> {
+        let slot = block.slot();
+        let block_time = block.block_time();
+        let was_skipped = block.was_skipped();
+        async move {
+            if was_skipped {
+                return Ok(());
+            }
+
+            let rows = Self::take_slot_events(slot, block_time);
+
+            if let Some(db_client) = db
+                && !rows.is_empty()
+            {
+                tokio::spawn(async move {
+                    if let Err(err) = write_pubkey_mentions(db_client, rows).await {
+                        log::error!("failed to write pubkey mentions: {}", err);
+                    }
+                });
+            }
+
+            Ok(())
+        }
+        .boxed()
+    }
+
+    #[inline(always)]
+    fn on_load(&self, db: Option<Arc<Client>>) -> PluginFuture<'_> {
+        async move {
+            log::info!("Pubkey Stats Plugin loaded.");
+            if let Some(db) = db {
+                log::info!("Creating pubkey_mentions table if it does not exist...");
+                db.query(
+                    r#"
+                    CREATE TABLE IF NOT EXISTS pubkey_mentions (
+                        slot          UInt32,
+                        timestamp     DateTime('UTC'),
+                        pubkey        FixedString(32),
+                        num_mentions  UInt32
+                    )
+                    ENGINE = ReplacingMergeTree(timestamp)
+                    ORDER BY (slot, pubkey)
+                    "#,
+                )
+                .execute()
+                .await?;
+
+                log::info!("Creating pubkeys table if it does not exist...");
+                db.query(
+                    r#"
+                    CREATE TABLE IF NOT EXISTS pubkeys (
+                        pubkey  FixedString(32),
+                        id      UInt64
+                    )
+                    ENGINE = ReplacingMergeTree()
+                    ORDER BY pubkey
+                    "#,
+                )
+                .execute()
+                .await?;
+
+                log::info!("Creating pubkeys materialised view if it does not exist...");
+                db.query(
+                    r#"
+                    CREATE MATERIALIZED VIEW IF NOT EXISTS pubkeys_mv TO pubkeys AS
+                    SELECT
+                        pubkey,
+                        sipHash64(pubkey) AS id
+                    FROM pubkey_mentions
+                    GROUP BY pubkey
+                    "#,
+                )
+                .execute()
+                .await?;
+
+                log::info!("done.");
+            } else {
+                log::warn!(
+                    "Pubkey Stats Plugin running without ClickHouse; data will not be persisted."
+                );
+            }
+            Ok(())
+        }
+        .boxed()
+    }
+
+    #[inline(always)]
+    fn on_exit(&self, db: Option<Arc<Client>>) -> PluginFuture<'_> {
+        async move {
+            if let Some(db_client) = db {
+                let rows = Self::drain_all_pending(None);
+                if !rows.is_empty() {
+                    write_pubkey_mentions(Arc::clone(&db_client), rows)
+                        .await
+                        .map_err(|err| -> Box<dyn std::error::Error + Send + Sync> {
+                            Box::new(err)
+                        })?;
+                }
+                backfill_pubkey_timestamps(db_client)
+                    .await
+                    .map_err(|err| -> Box<dyn std::error::Error + Send + Sync> { Box::new(err) })?;
+            }
+            Ok(())
+        }
+        .boxed()
+    }
+}
+
+async fn write_pubkey_mentions(
+    db: Arc<Client>,
+    rows: Vec<PubkeyMention>,
+) -> Result<(), clickhouse::error::Error> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    let mut insert = db.insert::<PubkeyMention>("pubkey_mentions").await?;
+    for row in rows {
+        insert.write(&row).await?;
+    }
+    insert.end().await?;
+    Ok(())
+}
+
+fn clamp_block_time(block_time: Option<i64>) -> u32 {
+    let Some(raw_ts) = block_time else {
+        return 0;
+    };
+    if raw_ts < 0 {
+        0
+    } else if raw_ts > u32::MAX as i64 {
+        u32::MAX
+    } else {
+        raw_ts as u32
+    }
+}
+
+async fn backfill_pubkey_timestamps(db: Arc<Client>) -> Result<(), clickhouse::error::Error> {
+    db.query(
+        r#"
+        INSERT INTO pubkey_mentions
+        SELECT pm.slot,
+               ss.block_time,
+               pm.pubkey,
+               pm.num_mentions
+        FROM pubkey_mentions AS pm
+        ANY INNER JOIN jetstreamer_slot_status AS ss USING (slot)
+        WHERE pm.timestamp = toDateTime(0)
+          AND ss.block_time > toDateTime(0)
+        "#,
+    )
+    .execute()
+    .await?;
+
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,6 +130,7 @@ use jetstreamer_plugin::{
     Plugin, PluginRunner, PluginRunnerError,
     plugins::{
         instruction_tracking::InstructionTrackingPlugin, program_tracking::ProgramTrackingPlugin,
+        pubkey_stats::PubkeyStatsPlugin,
     },
 };
 use std::sync::Arc;
@@ -569,6 +570,8 @@ pub enum BuiltinPlugin {
     ProgramTracking,
     /// Instruction Tracking.
     InstructionTracking,
+    /// Pubkey Stats.
+    PubkeyStats,
 }
 
 impl BuiltinPlugin {
@@ -576,6 +579,7 @@ impl BuiltinPlugin {
         match value {
             "program-tracking" => Some(Self::ProgramTracking),
             "instruction-tracking" => Some(Self::InstructionTracking),
+            "pubkey-stats" => Some(Self::PubkeyStats),
             _ => None,
         }
     }
@@ -584,6 +588,7 @@ impl BuiltinPlugin {
         match self {
             Self::ProgramTracking => Box::new(ProgramTrackingPlugin::new()),
             Self::InstructionTracking => Box::new(InstructionTrackingPlugin::new()),
+            Self::PubkeyStats => Box::new(PubkeyStatsPlugin::new()),
         }
     }
 }
@@ -598,8 +603,8 @@ impl BuiltinPlugin {
 /// - `JETSTREAMER_BUFFER_WINDOW`: Optional ripget sequential window size (for example `4GiB`).
 ///
 /// CLI flags:
-/// - `--with-plugin <name>`: Adds one of the built-in plugins (`program-tracking` or
-///   `instruction-tracking`). When omitted, the CLI defaults to `program-tracking`.
+/// - `--with-plugin <name>`: Adds one of the built-in plugins (`program-tracking`,
+///   `instruction-tracking`, or `pubkey-stats`). When omitted, the CLI defaults to `program-tracking`.
 /// - `--no-plugins`: Disables all built-in plugins (overrides the default and any `--with-plugin`).
 /// - `--sequential`: Enables single-thread sequential firehose mode.
 /// - `--buffer-window <size>`: Overrides ripget sequential window size (for example `4GiB`).
@@ -632,7 +637,7 @@ pub fn parse_cli_args() -> Result<Config, Box<dyn std::error::Error>> {
                     .ok_or_else(|| "--with-plugin requires a plugin name".to_string())?;
                 let plugin = BuiltinPlugin::from_flag(&plugin_name).ok_or_else(|| {
                     format!(
-                        "unknown plugin '{plugin_name}'. expected 'program-tracking' or 'instruction-tracking'"
+                        "unknown plugin '{plugin_name}'. expected 'program-tracking', 'instruction-tracking', or 'pubkey-stats'"
                     )
                 })?;
                 builtin_plugins.push(plugin);


### PR DESCRIPTION
## Summary
- Add `PubkeyStatsPlugin` that tracks per-slot pubkey mention counts in a `pubkey_mentions` ClickHouse table, with a `pubkeys` table and materialized view for unique pubkey lookups
- Fix TLS regression from `e2e9c11` that switched to rustls, dropping throughput from 2.7M to 400k TPS
- Switch all `HashMap`/`DashMap`/`DashSet` instances to use `ahash::RandomState` for faster hashing in hot paths
- Bump workspace version to 0.5.1

## Test plan
- [x] Run `--with-plugin pubkey-stats` against a test epoch and verify `pubkey_mentions` and `pubkeys` tables populate correctly
- [x] Verify TPS is at or above 3M on high-performance hardware
- [x] Query `SELECT base58Encode(pubkey), sum(num_mentions) FROM pubkey_mentions GROUP BY pubkey ORDER BY 2 DESC LIMIT 10` to confirm data integrity
