### PR TITLE
docs: fix typos and small wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Jetstreamer is split across four crates:
   Faithful CAR archives at scale.
 - `jetstreamer-plugin` – a trait-based framework for building structured observers with
   ClickHouse-friendly batching and runtime metrics.
-- `jetstreamer-utils` - utils used by the Jetstreamer ecosystem.
+- `jetstreamer-utils` – shared helpers used across the Jetstreamer ecosystem.
 
 Every crate ships with rich module-level documentation and runnable examples. Visit
 [docs.rs/jetstreamer](https://docs.rs/jetstreamer) to explore the API surface in detail.

--- a/jetstreamer-firehose/README.md
+++ b/jetstreamer-firehose/README.md
@@ -28,6 +28,7 @@ https://github.com/rpcpool/yellowstone-faithful/tree/main/geyser-plugin-runner
 - `JETSTREAMER_NETWORK_CAPACITY_MB` (default `1000`): assumed network throughput in megabytes
   per second when sizing the firehose thread pool. Increase or decrease to match your host's
   effective bandwidth.
+
 Notes:
 
 - `JETSTREAMER_HTTP_BASE_URL` and `JETSTREAMER_COMPACT_INDEX_BASE_URL` accept both full HTTP(S)

--- a/jetstreamer-firehose/src/firehose.rs
+++ b/jetstreamer-firehose/src/firehose.rs
@@ -132,8 +132,7 @@ async fn find_previous_indexed_slot(
     Ok(None)
 }
 
-/// Errors that can occur while streaming the firehose. Errors that can occur while streaming
-/// the firehose.
+/// Errors that can occur while streaming the firehose.
 #[derive(Debug, Error)]
 pub enum FirehoseError {
     /// HTTP client error surfaced from `reqwest`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,7 +208,7 @@ fn parse_clickhouse_mode(value: &str) -> Option<ClickhouseMode> {
 ///
 /// Configure the runner with the builder-style methods and finish by calling
 /// [`JetstreamerRunner::run`]. The runner also honors the process-level environment variables
-/// documented at the module level
+/// documented at the module level.
 ///
 /// ### Environment variables
 ///
@@ -311,7 +311,7 @@ fn parse_clickhouse_mode(value: &str) -> Option<ClickhouseMode> {
 ///
 /// To achieve 2M TPS+, you will need a 20+ Gbps network connection and at least a 64 core CPU.
 /// On our benchmark hardware we currently have a 100 Gbps connection and 64 cores, which has
-/// led to a record of 2.7M TPS of the course of a 12 hour run using 255 threads.
+/// led to a record of 2.7M TPS over the course of a 12 hour run using 255 threads.
 pub struct JetstreamerRunner {
     log_level: String,
     plugins: Vec<Box<dyn Plugin>>,


### PR DESCRIPTION
- src/lib.rs: add missing period; "of the course" -> "over the course"
- firehose.rs: remove duplicated FirehoseError doc sentence
- README.md: correct crate count (three -> four); tidy utils bullet
- firehose README: blank line before Notes for proper Markdown