### PR TITLE
Install build dependencies in release workflow jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,6 +32,11 @@ jobs:
           ref: ${{ inputs.ref }}
           persist-credentials: false
 
+      - name: Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libudev-dev clang llvm-dev libclang-dev pkg-config libssl-dev
+
       - name: Compute metadata
         id: meta
         run: |
@@ -107,6 +112,11 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
           persist-credentials: false
           ref: ${{ needs.check.outputs.ref }}
+
+      - name: Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libudev-dev clang llvm-dev libclang-dev pkg-config libssl-dev
 
       - name: Package crate
         run: cargo package -p "${CRATE_NAME}"


### PR DESCRIPTION
The release workflow's \`check\` job runs \`cargo publish --dry-run\` (and \`publish\` runs \`cargo package\`, which also verifies the build) on a bare runner without the apt packages the CI workflow installs. Any crate whose dependency tree needs libclang/bindgen — \`jetstreamer-firehose\`, and transitively \`jetstreamer-plugin\` and \`jetstreamer\` — fails with \`clang-sys\`'s "couldn't find any valid shared libraries matching libclang.so" (observed in [run 30597317711](https://github.com/anza-xyz/jetstreamer/actions/runs/30597317711) while releasing 0.7.0). \`jetstreamer-utils\` passed only because its tree doesn't touch bindgen.

This adds the same \`Dependencies\` apt step used by \`rust.yaml\` to both release jobs.

Blocks the in-progress 0.7.0 release chain, which Triton is waiting on.