### PR TITLE
Consolidate release workflow: one dispatch releases the whole workspace

### DIFF
--- a/.github/scripts/release-crate.sh
+++ b/.github/scripts/release-crate.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
-# Publishes one workspace crate to crates.io, tags it, and creates its GitHub
-# release. Skips cleanly when the crate@vX.Y.Z tag already exists, which makes
-# the workspace release workflow resumable: re-running it only releases the
-# crates that have not shipped yet.
+# Idempotently releases one workspace crate. The three effects — publish to
+# crates.io, push the crate@vX.Y.Z tag, create the GitHub release — are checked
+# and performed independently, so re-running after a partial failure completes
+# exactly the missing steps: a publish whose tag push failed is not re-published,
+# a tagged crate whose GitHub release failed still gets its release, etc.
+#
+# Emits `published=true|false` (whether THIS run performed the crates.io
+# publish) to GITHUB_OUTPUT so the workflow can attest provenance for exactly
+# the crates packaged in this run.
 #
 # Usage: release-crate.sh <crate-name>
 # Env:   CARGO_REGISTRY_TOKEN (crates.io), GITHUB_TOKEN (tag push + gh release)
@@ -17,20 +22,45 @@ if [ -z "${version}" ] || [ "${version}" = "null" ]; then
   exit 1
 fi
 tag="${crate}@v${version}"
+summary="${GITHUB_STEP_SUMMARY:-/dev/null}"
 
-if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
-  echo "==> ${tag} already released; skipping"
-  echo "- \`${tag}\`: skipped (already released)" >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
-  exit 0
+published_on_registry() {
+  curl -fsSL --retry 3 \
+    -H "User-Agent: jetstreamer-release-workflow (github.com/anza-xyz/jetstreamer)" \
+    "https://crates.io/api/v1/crates/${crate}/${version}" 2>/dev/null |
+    jq -e ".version.num == \"${version}\"" >/dev/null 2>&1
+}
+
+published_this_run=false
+if published_on_registry; then
+  echo "==> ${tag}: already on crates.io; skipping publish"
+  echo "- \`${tag}\`: publish skipped (already on crates.io)" >> "${summary}"
+else
+  echo "==> ${tag}: publishing to crates.io"
+  # cargo blocks until the published crate is available in the registry index,
+  # so the next crate in dependency order can resolve it immediately.
+  cargo publish -p "${crate}"
+  published_this_run=true
+  echo "- \`${tag}\`: published to crates.io" >> "${summary}"
 fi
 
-echo "==> publishing ${tag}"
-# cargo blocks until the published crate is available in the registry index, so
-# the next crate in dependency order can resolve it immediately.
-cargo publish -p "${crate}"
+if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+  echo "==> ${tag}: tag already exists; skipping tag push"
+  echo "- \`${tag}\`: tag skipped (already exists)" >> "${summary}"
+else
+  echo "==> ${tag}: pushing tag"
+  git tag -a "${tag}" -m "Release ${tag}"
+  git push origin "${tag}"
+  echo "- \`${tag}\`: tag pushed" >> "${summary}"
+fi
 
-git tag -a "${tag}" -m "Release ${tag}"
-git push origin "${tag}"
-gh release create "${tag}" --title "${tag}" --generate-notes
+if gh release view "${tag}" >/dev/null 2>&1; then
+  echo "==> ${tag}: GitHub release already exists; skipping"
+  echo "- \`${tag}\`: GitHub release skipped (already exists)" >> "${summary}"
+else
+  echo "==> ${tag}: creating GitHub release"
+  gh release create "${tag}" --title "${tag}" --generate-notes
+  echo "- \`${tag}\`: GitHub release created" >> "${summary}"
+fi
 
-echo "- \`${tag}\`: published" >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+echo "published=${published_this_run}" >> "${GITHUB_OUTPUT:-/dev/null}"

--- a/.github/scripts/release-crate.sh
+++ b/.github/scripts/release-crate.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# Publishes one workspace crate to crates.io, tags it, and creates its GitHub
+# release. Skips cleanly when the crate@vX.Y.Z tag already exists, which makes
+# the workspace release workflow resumable: re-running it only releases the
+# crates that have not shipped yet.
+#
+# Usage: release-crate.sh <crate-name>
+# Env:   CARGO_REGISTRY_TOKEN (crates.io), GITHUB_TOKEN (tag push + gh release)
+set -euo pipefail
+
+crate="$1"
+
+version=$(cargo metadata --format-version 1 --no-deps |
+  jq -r ".packages[] | select(.name == \"${crate}\") | .version")
+if [ -z "${version}" ] || [ "${version}" = "null" ]; then
+  echo "!! could not resolve version for ${crate}" >&2
+  exit 1
+fi
+tag="${crate}@v${version}"
+
+if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+  echo "==> ${tag} already released; skipping"
+  echo "- \`${tag}\`: skipped (already released)" >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+  exit 0
+fi
+
+echo "==> publishing ${tag}"
+# cargo blocks until the published crate is available in the registry index, so
+# the next crate in dependency order can resolve it immediately.
+cargo publish -p "${crate}"
+
+git tag -a "${tag}" -m "Release ${tag}"
+git push origin "${tag}"
+gh release create "${tag}" --title "${tag}" --generate-notes
+
+echo "- \`${tag}\`: published" >> "${GITHUB_STEP_SUMMARY:-/dev/null}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-22.04-8core
+    runs-on: ubuntu-latest
     outputs:
       ref: ${{ steps.plan.outputs.ref }}
       first: ${{ steps.plan.outputs.first }}
@@ -90,7 +90,7 @@ jobs:
           FIRST: ${{ steps.plan.outputs.first }}
 
   publish:
-    runs-on: ubuntu-22.04-8core
+    runs-on: ubuntu-latest
     environment: prod
     needs: check
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,11 @@ name: Release
 
 # Releases the entire workspace in dependency order with a single dispatch and a
 # single prod approval: jetstreamer-utils -> jetstreamer-firehose ->
-# jetstreamer-plugin -> jetstreamer. Crates whose crate@vX.Y.Z tag already
-# exists are skipped, so an interrupted release can be resumed by re-running the
-# workflow. Versions are bumped workspace-wide in a PR before dispatching.
+# jetstreamer-plugin -> jetstreamer. For each crate the three effects — crates.io
+# publish, crate@vX.Y.Z tag, GitHub release — are checked and performed
+# independently, so an interrupted release can be resumed by re-running the
+# workflow and only the missing effects are performed. Versions are bumped
+# workspace-wide in a PR before dispatching.
 
 on:
   workflow_dispatch:
@@ -35,8 +37,11 @@ jobs:
 
       - name: Compute release plan
         id: plan
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           first=""
+          work=false
           echo "## Release plan" >> "${GITHUB_STEP_SUMMARY}"
           for crate in jetstreamer-utils jetstreamer-firehose jetstreamer-plugin jetstreamer; do
             version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "'"${crate}"'") | .version')"
@@ -45,27 +50,41 @@ jobs:
               exit 1
             fi
             tag="${crate}@v${version}"
-            if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
-              echo "- \`${tag}\`: already released, will skip" >> "${GITHUB_STEP_SUMMARY}"
-            else
-              echo "- \`${tag}\`: will release" >> "${GITHUB_STEP_SUMMARY}"
+            todo=""
+            if ! curl -fsSL --retry 3 -H "User-Agent: jetstreamer-release-workflow (github.com/anza-xyz/jetstreamer)" \
+              "https://crates.io/api/v1/crates/${crate}/${version}" 2>/dev/null | jq -e '.version.num == "'"${version}"'"' >/dev/null 2>&1; then
+              todo="publish"
               if [ -z "${first}" ]; then
                 first="${crate}"
               fi
             fi
+            if ! git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+              todo="${todo:+${todo}, }tag"
+            fi
+            if ! gh release view "${tag}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              todo="${todo:+${todo}, }github release"
+            fi
+            if [ -n "${todo}" ]; then
+              work=true
+              echo "- \`${tag}\`: needs ${todo}" >> "${GITHUB_STEP_SUMMARY}"
+            else
+              echo "- \`${tag}\`: fully released, will skip" >> "${GITHUB_STEP_SUMMARY}"
+            fi
           done
-          if [ -z "${first}" ]; then
-            echo "Every crate at the current version is already released. Bump versions first."
+          if [ "${work}" = "false" ]; then
+            echo "Every crate at the current version is already fully released. Bump versions first."
             exit 1
           fi
           echo "first=${first}" >> "${GITHUB_OUTPUT}"
           echo "ref=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
-      # Because versions bump workspace-wide and releases run in dependency
-      # order, the first unreleased crate's workspace dependencies are always
+      # Because versions bump workspace-wide and publishing runs in dependency
+      # order, the first unpublished crate's workspace dependencies are always
       # already on crates.io — so it is always dry-runnable. Later crates depend
       # on unpublished versions and are validated by `cargo publish` itself.
-      - name: Cargo publish dry run (first unreleased crate)
+      # Skipped entirely when only tags/releases are missing (nothing to publish).
+      - name: Cargo publish dry run (first unpublished crate)
+        if: steps.plan.outputs.first != ''
         run: cargo publish -p "${FIRST}" --dry-run
         env:
           FIRST: ${{ steps.plan.outputs.first }}
@@ -112,43 +131,67 @@ jobs:
       # Each crate gets a freshly minted crates.io token immediately before its
       # publish: verification builds are long enough that a single token could
       # expire before the last crate publishes.
+      # Provenance is attested per crate, immediately after its publish and only
+      # when THIS run performed the publish — so a partially-failed release never
+      # leaves a published crate unattested, and reruns never re-attest crates
+      # they merely skipped.
       - name: Create crate token (jetstreamer-utils)
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth-utils
       - name: Release jetstreamer-utils
+        id: release-utils
         run: .github/scripts/release-crate.sh jetstreamer-utils
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth-utils.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Generate SLSA provenance (jetstreamer-utils)
+        if: steps.release-utils.outputs.published == 'true'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: target/package/jetstreamer-utils-*.crate
 
       - name: Create crate token (jetstreamer-firehose)
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth-firehose
       - name: Release jetstreamer-firehose
+        id: release-firehose
         run: .github/scripts/release-crate.sh jetstreamer-firehose
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth-firehose.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Generate SLSA provenance (jetstreamer-firehose)
+        if: steps.release-firehose.outputs.published == 'true'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: target/package/jetstreamer-firehose-*.crate
 
       - name: Create crate token (jetstreamer-plugin)
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth-plugin
       - name: Release jetstreamer-plugin
+        id: release-plugin
         run: .github/scripts/release-crate.sh jetstreamer-plugin
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth-plugin.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+      - name: Generate SLSA provenance (jetstreamer-plugin)
+        if: steps.release-plugin.outputs.published == 'true'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: target/package/jetstreamer-plugin-*.crate
 
       - name: Create crate token (jetstreamer)
         uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
         id: auth-jetstreamer
       - name: Release jetstreamer
+        id: release-jetstreamer
         run: .github/scripts/release-crate.sh jetstreamer
         env:
           CARGO_REGISTRY_TOKEN: ${{ steps.auth-jetstreamer.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-
-      - name: Generate SLSA provenance
+      - name: Generate SLSA provenance (jetstreamer)
+        if: steps.release-jetstreamer.outputs.published == 'true'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
-          subject-path: target/package/*.crate
+          # [0-9] keeps the glob from also matching jetstreamer-{utils,...}
+          subject-path: target/package/jetstreamer-[0-9]*.crate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,26 @@
 name: Release
 
+# Releases the entire workspace in dependency order with a single dispatch and a
+# single prod approval: jetstreamer-utils -> jetstreamer-firehose ->
+# jetstreamer-plugin -> jetstreamer. Crates whose crate@vX.Y.Z tag already
+# exists are skipped, so an interrupted release can be resumed by re-running the
+# workflow. Versions are bumped workspace-wide in a PR before dispatching.
+
 on:
   workflow_dispatch:
     inputs:
-      crate:
-        description: "Crate to release"
-        required: true
-        type: choice
-        options:
-          - ""
-          - jetstreamer
-          - jetstreamer-plugin
-          - jetstreamer-utils
-          - jetstreamer-firehose
       ref:
-        description: "git ref to tag (can be a branch or a commit hash)"
+        description: "git ref to release (can be a branch or a commit hash)"
         required: true
         default: "main"
         type: string
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-8core
     outputs:
-      tag: ${{ steps.meta.outputs.tag }}
-      ref: ${{ steps.meta.outputs.ref }}
+      ref: ${{ steps.plan.outputs.ref }}
+      first: ${{ steps.plan.outputs.first }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -37,50 +33,45 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libudev-dev clang llvm-dev libclang-dev pkg-config libssl-dev
 
-      - name: Compute metadata
-        id: meta
+      - name: Compute release plan
+        id: plan
         run: |
-          version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "'"${CRATE_NAME}"'") | .version')"
-          if [ -z "${version}" ] || [ "${version}" = "null" ]; then
-            echo "Could not resolve version for crate: ${CRATE_NAME}"
+          first=""
+          echo "## Release plan" >> "${GITHUB_STEP_SUMMARY}"
+          for crate in jetstreamer-utils jetstreamer-firehose jetstreamer-plugin jetstreamer; do
+            version="$(cargo metadata --format-version 1 --no-deps | jq -r '.packages[] | select(.name == "'"${crate}"'") | .version')"
+            if [ -z "${version}" ] || [ "${version}" = "null" ]; then
+              echo "Could not resolve version for crate: ${crate}"
+              exit 1
+            fi
+            tag="${crate}@v${version}"
+            if git ls-remote --exit-code --tags origin "refs/tags/${tag}" >/dev/null 2>&1; then
+              echo "- \`${tag}\`: already released, will skip" >> "${GITHUB_STEP_SUMMARY}"
+            else
+              echo "- \`${tag}\`: will release" >> "${GITHUB_STEP_SUMMARY}"
+              if [ -z "${first}" ]; then
+                first="${crate}"
+              fi
+            fi
+          done
+          if [ -z "${first}" ]; then
+            echo "Every crate at the current version is already released. Bump versions first."
             exit 1
           fi
+          echo "first=${first}" >> "${GITHUB_OUTPUT}"
+          echo "ref=$(git rev-parse HEAD)" >> "${GITHUB_OUTPUT}"
 
-          tag="${CRATE_NAME}@v${version}"
-          ref="$(git rev-parse HEAD)"
-
-          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
-          echo "ref=${ref}" >> "${GITHUB_OUTPUT}"
+      # Because versions bump workspace-wide and releases run in dependency
+      # order, the first unreleased crate's workspace dependencies are always
+      # already on crates.io — so it is always dry-runnable. Later crates depend
+      # on unpublished versions and are validated by `cargo publish` itself.
+      - name: Cargo publish dry run (first unreleased crate)
+        run: cargo publish -p "${FIRST}" --dry-run
         env:
-          CRATE_NAME: ${{ inputs.crate }}
-
-      - name: Check tag does not exist
-        run: |
-          echo "checking: refs/tags/${TAG}"
-          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
-            echo "Tag already exists: ${TAG}. Please bump the version first (or delete the existing tag) and retry."
-            echo "Tag exists: ${TAG}" >> "${GITHUB_STEP_SUMMARY}"
-            exit 1
-          fi
-        env:
-          TAG: ${{ steps.meta.outputs.tag }}
-
-      - name: Cargo publish dry run
-        run: |
-          cargo publish -p "${CRATE_NAME}" --dry-run
-        env:
-          CRATE_NAME: ${{ inputs.crate }}
-
-      - name: Summary
-        run: |
-          echo "Tag: ${TAG}" >> "${GITHUB_STEP_SUMMARY}"
-          echo "Ref: ${REF} (https://github.com/${{ github.repository }}/commit/${REF})" >> "${GITHUB_STEP_SUMMARY}"
-        env:
-          TAG: ${{ steps.meta.outputs.tag }}
-          REF: ${{ steps.meta.outputs.ref }}
+          FIRST: ${{ steps.plan.outputs.first }}
 
   publish:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04-8core
     environment: prod
     needs: check
     permissions:
@@ -118,34 +109,46 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential libudev-dev clang llvm-dev libclang-dev pkg-config libssl-dev
 
-      - name: Package crate
-        run: cargo package -p "${CRATE_NAME}"
+      # Each crate gets a freshly minted crates.io token immediately before its
+      # publish: verification builds are long enough that a single token could
+      # expire before the last crate publishes.
+      - name: Create crate token (jetstreamer-utils)
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth-utils
+      - name: Release jetstreamer-utils
+        run: .github/scripts/release-crate.sh jetstreamer-utils
         env:
-          CRATE_NAME: ${{ inputs.crate }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-utils.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Create crate token (jetstreamer-firehose)
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth-firehose
+      - name: Release jetstreamer-firehose
+        run: .github/scripts/release-crate.sh jetstreamer-firehose
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-firehose.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Create crate token (jetstreamer-plugin)
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth-plugin
+      - name: Release jetstreamer-plugin
+        run: .github/scripts/release-crate.sh jetstreamer-plugin
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-plugin.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+      - name: Create crate token (jetstreamer)
+        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
+        id: auth-jetstreamer
+      - name: Release jetstreamer
+        run: .github/scripts/release-crate.sh jetstreamer
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth-jetstreamer.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Generate SLSA provenance
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: target/package/*.crate
-
-      - name: Create crate token
-        uses: rust-lang/crates-io-auth-action@c6f97d42243bad5fab37ca0427f495c86d5b1a18 # v1.0.5
-        id: auth
-
-      - run: cargo publish -p "${CRATE_NAME}"
-        env:
-          CRATE_NAME: ${{ inputs.crate }}
-          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
-
-      - run: |
-          git tag -a "${TAG}" -m "Release ${TAG}"
-          git push origin "${TAG}"
-        env:
-          TAG: ${{ needs.check.outputs.tag }}
-
-      - name: Create Github Release
-        run: |
-          gh release create "${TAG}" --title "${TAG}" --generate-notes
-        env:
-          TAG: ${{ needs.check.outputs.tag }}
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Jetstreamer releases are always workspace-wide (all four crates share the workspace version), so this replaces the per-crate release dispatch with a single workspace release: one `workflow_dispatch`, one `prod` approval, and the crates publish sequentially in dependency order (`jetstreamer-utils` → `jetstreamer-firehose` → `jetstreamer-plugin` → `jetstreamer`), each getting its `crate@vX.Y.Z` tag and GitHub release as before.

Design notes:

- **Resumable**: each crate is skipped when its tag already exists, so an interrupted release (like the currently half-done 0.7.0) is finished by simply re-running the workflow. The check job fails early if *everything* is already released (i.e. you forgot to bump).
- **Dry-run coverage**: because versions bump workspace-wide and publishing runs in dependency order, the *first* unreleased crate's workspace dependencies are always already on crates.io — so the check job can always dry-run it. Later crates depend on versions that don't exist on the registry until moments before, and are validated by `cargo publish` itself (which also blocks until each published crate is available in the index before the next resolves it).
- **Token freshness**: each crate mints its own crates.io token immediately before publishing — verification builds are long enough that a single token could expire before the fourth publish.
- **Fixed step order**: `publish` no longer packages before authenticating; provenance attestation runs once at the end over every packaged `.crate`.
- Per-crate release logic lives in `.github/scripts/release-crate.sh` instead of being repeated four times in YAML.

Stacked on #80 (the runner build-dependencies fix); merging this after #80 leaves a one-commit diff.