### PR TITLE
Fix reverse-mode epoch re-emission when an error strikes at an epoch tail

### DIFF
--- a/jetstreamer-firehose/src/firehose.rs
+++ b/jetstreamer-firehose/src/firehose.rs
@@ -514,6 +514,46 @@ async fn request_steal(
     None
 }
 
+/// Decides how a reverse-mode retry resumes after an error attributed to `slot`, given that
+/// `last_counted_slot` was the last slot fully processed. Returns the new
+/// `(reverse_partial_resume, reverse_highest_remaining_epoch)`.
+///
+/// The subtlety: an error striking at an epoch slice's *tail* (after its final block was
+/// emitted, before the clean end-of-epoch break) is attributed to the next slot — which
+/// belongs to the next, **higher** epoch. Storing that as the partial-resume point poisons
+/// the retry: the epoch-match check sees a foreign epoch, discards the resume marker, and
+/// re-processes the entire slice from its start, double-emitting every slot in it. When the
+/// resume point crosses above the epoch that was actually being processed, the slice is
+/// complete — so mark the epoch done instead.
+fn reverse_resume_after_error(
+    slot: u64,
+    last_counted_slot: u64,
+    highest_remaining_epoch: u64,
+) -> (Option<u64>, u64) {
+    let resume_slot = if slot <= last_counted_slot {
+        last_counted_slot.saturating_add(1)
+    } else {
+        slot
+    };
+    let last_epoch = slot_to_epoch(last_counted_slot);
+    let error_epoch = slot_to_epoch(slot);
+    if error_epoch >= last_epoch && slot_to_epoch(resume_slot) > last_epoch {
+        // Tail case: everything in `last_epoch` was processed. Only decrement the
+        // highest-remaining marker when it still points at that epoch (it may already point
+        // lower, e.g. when the error arrived before the first block of an earlier epoch).
+        let highest = if highest_remaining_epoch == last_epoch {
+            // May drop below the range's lowest epoch, which the retry loop treats as
+            // "all epochs complete" and exits cleanly.
+            highest_remaining_epoch.saturating_sub(1)
+        } else {
+            highest_remaining_epoch
+        };
+        (None, highest)
+    } else {
+        (Some(resume_slot), highest_remaining_epoch)
+    }
+}
+
 /// Per-thread restart pacing: consecutive failures on the same slot double the delay up to
 /// [`RETRY_BACKOFF_MAX`]; a failure on a different slot means forward progress was made and
 /// resets the sequence.
@@ -2596,12 +2636,13 @@ where
                     // In reverse mode, completed higher epochs are tracked via
                     // reverse_highest_remaining_epoch and the within-epoch resume slot lives in
                     // reverse_partial_resume; slot_range stays at its original bounds.
-                    let resume_slot = if slot <= last_counted_slot {
-                        last_counted_slot.saturating_add(1)
-                    } else {
-                        slot
-                    };
-                    reverse_partial_resume = Some(resume_slot);
+                    let (resume, highest) = reverse_resume_after_error(
+                        slot,
+                        last_counted_slot,
+                        reverse_highest_remaining_epoch,
+                    );
+                    reverse_partial_resume = resume;
+                    reverse_highest_remaining_epoch = highest;
                 } else if slot <= last_counted_slot {
                     slot_range.start = last_counted_slot.saturating_add(1);
                 } else {
@@ -3505,6 +3546,57 @@ fn human_readable_duration(duration: std::time::Duration) -> String {
         } else {
             format!("{secs}s")
         }
+    }
+}
+
+#[cfg(test)]
+mod reverse_resume_tests {
+    use super::*;
+
+    // Epoch 899 spans slots 388368000..=388799999; epoch 900 starts at 388800000.
+
+    #[test]
+    fn test_mid_epoch_error_resumes_in_place() {
+        let (resume, highest) = reverse_resume_after_error(388799951, 388799950, 899);
+        assert_eq!(resume, Some(388799951));
+        assert_eq!(highest, 899);
+    }
+
+    #[test]
+    fn test_tail_timeout_marks_epoch_complete() {
+        // Error attributed to the next epoch's first slot after the tail slot was counted:
+        // the epoch slice is done; resuming from the slice start would double-emit it.
+        let (resume, highest) = reverse_resume_after_error(388800000, 388799999, 899);
+        assert_eq!(resume, None);
+        assert_eq!(highest, 898);
+    }
+
+    #[test]
+    fn test_tail_error_attributed_within_epoch_marks_complete() {
+        // Decoding error attributed to the already-counted tail slot: resume would be
+        // tail + 1, crossing the boundary — same completion case.
+        let (resume, highest) = reverse_resume_after_error(388799999, 388799999, 899);
+        assert_eq!(resume, None);
+        assert_eq!(highest, 898);
+    }
+
+    #[test]
+    fn test_seek_error_before_any_progress_keeps_epoch() {
+        // First epoch (900) seek fails before any block; last_counted is still the
+        // pre-range sentinel in epoch 899. The higher epoch must not be marked complete.
+        let (resume, highest) = reverse_resume_after_error(388800000, 388799899, 900);
+        assert_eq!(resume, None);
+        assert_eq!(highest, 900);
+    }
+
+    #[test]
+    fn test_lower_epoch_seek_error_after_higher_done_resumes() {
+        // Epoch 900 finished (last_counted in 900); epoch 899's seek fails with the error
+        // attributed inside 899. Not a tail crossing — keep a resume marker (which the
+        // epoch-match check resolves to the slice start of 899).
+        let (resume, highest) = reverse_resume_after_error(388799900, 388800099, 899);
+        assert_eq!(resume, Some(388800100));
+        assert_eq!(highest, 899);
     }
 }
 

--- a/jetstreamer-firehose/src/firehose.rs
+++ b/jetstreamer-firehose/src/firehose.rs
@@ -528,8 +528,8 @@ async fn request_steal(
 fn reverse_resume_after_error(
     slot: u64,
     last_counted_slot: u64,
-    highest_remaining_epoch: u64,
-) -> (Option<u64>, u64) {
+    highest_remaining_epoch: Option<u64>,
+) -> (Option<u64>, Option<u64>) {
     let resume_slot = if slot <= last_counted_slot {
         last_counted_slot.saturating_add(1)
     } else {
@@ -541,10 +541,11 @@ fn reverse_resume_after_error(
         // Tail case: everything in `last_epoch` was processed. Only decrement the
         // highest-remaining marker when it still points at that epoch (it may already point
         // lower, e.g. when the error arrived before the first block of an earlier epoch).
-        let highest = if highest_remaining_epoch == last_epoch {
-            // May drop below the range's lowest epoch, which the retry loop treats as
-            // "all epochs complete" and exits cleanly.
-            highest_remaining_epoch.saturating_sub(1)
+        let highest = if highest_remaining_epoch == Some(last_epoch) {
+            // `checked_sub` makes "no epochs remaining" explicit as `None` — required for
+            // epoch 0, where a saturating subtraction would silently stay at 0 and replay
+            // the epoch. Dropping below the range's lowest epoch also completes the run.
+            last_epoch.checked_sub(1)
         } else {
             highest_remaining_epoch
         };
@@ -1617,12 +1618,14 @@ where
             }
             let mut last_counted_slot = slot_range.start.saturating_sub(1);
             let mut last_emitted_slot_global = slot_range.start.saturating_sub(1);
-            // Reverse-mode state preserved across retries.
+            // Reverse-mode state preserved across retries. `None` for the highest remaining
+            // epoch explicitly means "every epoch is complete" — required so completing
+            // epoch 0 is distinguishable from epoch 0 still pending.
             let mut reverse_partial_resume: Option<u64> = None;
-            let mut reverse_highest_remaining_epoch: u64 = if reverse_mode_local {
-                slot_to_epoch(slot_range.end.saturating_sub(1))
+            let mut reverse_highest_remaining_epoch: Option<u64> = if reverse_mode_local {
+                Some(slot_to_epoch(slot_range.end.saturating_sub(1)))
             } else {
-                0
+                None
             };
             let mut thread_stats = if tracking_enabled {
                 Some(ThreadStats {
@@ -1693,13 +1696,14 @@ where
                 // for each epoch
                 let mut current_slot: Option<u64> = None;
                 let epoch_iter: Vec<u64> = if reverse_mode_local {
-                    if reverse_highest_remaining_epoch < lowest_epoch {
-                        // All epochs already completed across previous retries.
+                    // All epochs already completed across previous retries?
+                    let Some(highest_remaining) = reverse_highest_remaining_epoch else {
+                        return Ok(());
+                    };
+                    if highest_remaining < lowest_epoch {
                         return Ok(());
                     }
-                    (lowest_epoch..=reverse_highest_remaining_epoch)
-                        .rev()
-                        .collect()
+                    (lowest_epoch..=highest_remaining).rev().collect()
                 } else {
                     epoch_range.clone().collect()
                 };
@@ -2449,10 +2453,10 @@ where
                         }
                     }
                     if reverse_mode_local {
-                        // Mark this epoch as fully processed so retries skip it.
-                        if epoch_num == reverse_highest_remaining_epoch {
-                            reverse_highest_remaining_epoch =
-                                reverse_highest_remaining_epoch.saturating_sub(1);
+                        // Mark this epoch as fully processed so retries skip it
+                        // (`checked_sub` yields `None` at epoch 0: nothing remains).
+                        if reverse_highest_remaining_epoch == Some(epoch_num) {
+                            reverse_highest_remaining_epoch = epoch_num.checked_sub(1);
                         }
                         if matches!(
                             reverse_partial_resume,
@@ -3557,36 +3561,36 @@ mod reverse_resume_tests {
 
     #[test]
     fn test_mid_epoch_error_resumes_in_place() {
-        let (resume, highest) = reverse_resume_after_error(388799951, 388799950, 899);
+        let (resume, highest) = reverse_resume_after_error(388799951, 388799950, Some(899));
         assert_eq!(resume, Some(388799951));
-        assert_eq!(highest, 899);
+        assert_eq!(highest, Some(899));
     }
 
     #[test]
     fn test_tail_timeout_marks_epoch_complete() {
         // Error attributed to the next epoch's first slot after the tail slot was counted:
         // the epoch slice is done; resuming from the slice start would double-emit it.
-        let (resume, highest) = reverse_resume_after_error(388800000, 388799999, 899);
+        let (resume, highest) = reverse_resume_after_error(388800000, 388799999, Some(899));
         assert_eq!(resume, None);
-        assert_eq!(highest, 898);
+        assert_eq!(highest, Some(898));
     }
 
     #[test]
     fn test_tail_error_attributed_within_epoch_marks_complete() {
         // Decoding error attributed to the already-counted tail slot: resume would be
         // tail + 1, crossing the boundary — same completion case.
-        let (resume, highest) = reverse_resume_after_error(388799999, 388799999, 899);
+        let (resume, highest) = reverse_resume_after_error(388799999, 388799999, Some(899));
         assert_eq!(resume, None);
-        assert_eq!(highest, 898);
+        assert_eq!(highest, Some(898));
     }
 
     #[test]
     fn test_seek_error_before_any_progress_keeps_epoch() {
         // First epoch (900) seek fails before any block; last_counted is still the
         // pre-range sentinel in epoch 899. The higher epoch must not be marked complete.
-        let (resume, highest) = reverse_resume_after_error(388800000, 388799899, 900);
+        let (resume, highest) = reverse_resume_after_error(388800000, 388799899, Some(900));
         assert_eq!(resume, None);
-        assert_eq!(highest, 900);
+        assert_eq!(highest, Some(900));
     }
 
     #[test]
@@ -3594,9 +3598,19 @@ mod reverse_resume_tests {
         // Epoch 900 finished (last_counted in 900); epoch 899's seek fails with the error
         // attributed inside 899. Not a tail crossing — keep a resume marker (which the
         // epoch-match check resolves to the slice start of 899).
-        let (resume, highest) = reverse_resume_after_error(388799900, 388800099, 899);
+        let (resume, highest) = reverse_resume_after_error(388799900, 388800099, Some(899));
         assert_eq!(resume, Some(388800100));
-        assert_eq!(highest, 899);
+        assert_eq!(highest, Some(899));
+    }
+
+    #[test]
+    fn test_epoch_zero_tail_error_completes_run() {
+        // Epoch 0's tail is slot 431999; the error is attributed to slot 432000 (epoch 1).
+        // "No epochs remaining" must be explicit (`None`) — a saturating subtraction would
+        // silently pin at 0 and replay epoch 0 forever.
+        let (resume, highest) = reverse_resume_after_error(432000, 431999, Some(0));
+        assert_eq!(resume, None);
+        assert_eq!(highest, None);
     }
 }
 


### PR DESCRIPTION
Fixes the intermittent CI failure in `test_firehose_sequential_reverse_crosses_epoch_boundary` (seen on #80 and #81 runs):

```
within epoch 899, slot regressed: prev=388799999 now=388799900
```

## Root cause

In reverse mode, when an error (typically a network stall on slow CI runners) strikes at the **tail** of an epoch slice — after its final block was emitted but before the clean end-of-epoch break — the retry attributes the error to `current_slot + 1`, which belongs to the next, **higher** epoch. The handler stored that as `reverse_partial_resume`, and on restart the epoch iteration's epoch-match check saw a foreign epoch, discarded the resume marker, and re-seeked to the **slice start** — re-emitting the entire epoch slice. A `NodeDecodingError` attributed to the final counted slot triggers the same thing through the `slot <= last_counted` path (`resume = tail + 1` crosses the boundary).

This only reproduces when a stall lands exactly at an epoch tail, which is why fast local runs never see it and CI hits it intermittently.

## Fix

Resume bookkeeping is extracted into `reverse_resume_after_error`: when the computed resume point crosses **above** the epoch that was actually being processed, the slice is complete — the epoch is marked done (decrementing `reverse_highest_remaining_epoch` when it still points there) instead of storing a poisoned resume marker. Genuine mid-epoch errors resume in place exactly as before, and errors that arrive before an epoch's first block keep their existing behavior.

## Verification

- Five new unit tests covering the decision table: mid-epoch resume, tail timeout (next-epoch attribution), tail decoding error (same-epoch attribution), first-epoch seek failure before any progress (must **not** mark anything complete), and a lower-epoch seek failure after a higher epoch finished.
- The live `test_firehose_sequential_reverse_crosses_epoch_boundary` passes against the fix.
- `cargo fmt` / `clippy --all-features` clean.