### PR TITLE
Reject malformed DAG-CBOR CID links instead of panicking

### DIFF
--- a/jetstreamer-firehose/src/block.rs
+++ b/jetstreamer-firehose/src/block.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{SharedError, node::Kind},
+    crate::{SharedError, node::Kind, node_reader::cid_from_cbor_link},
     cid::Cid,
     std::vec::Vec,
 };
@@ -95,11 +95,7 @@ impl Block {
 
             if let Some(serde_cbor::Value::Array(entries)) = &array.get(3) {
                 for entry in entries {
-                    if let serde_cbor::Value::Bytes(entry) = entry {
-                        block
-                            .entries
-                            .push(Cid::try_from(entry[1..].to_vec()).unwrap());
-                    }
+                    block.entries.push(cid_from_cbor_link(entry)?);
                 }
             }
 
@@ -107,8 +103,8 @@ impl Block {
                 block.meta = SlotMeta::from_cbor(serde_cbor::Value::Array(meta.clone()));
             }
 
-            if let Some(serde_cbor::Value::Bytes(rewards)) = &array.get(5) {
-                block.rewards = Cid::try_from(rewards[1..].to_vec()).unwrap();
+            if let Some(rewards @ serde_cbor::Value::Bytes(_)) = array.get(5) {
+                block.rewards = cid_from_cbor_link(rewards)?;
             }
         }
         Ok(block)
@@ -148,6 +144,37 @@ impl Block {
 #[cfg(test)]
 mod block_tests {
     use super::*;
+
+    /// A DAG-CBOR CID link is a byte string whose first byte is the `0x00` multibase
+    /// prefix followed by the CID bytes. Malformed Old Faithful archives can supply an
+    /// empty or truncated byte string; decoding such a block must surface an error rather
+    /// than panic (previously `Cid::try_from(bytes[1..]).unwrap()` panicked on both).
+    #[test]
+    fn test_block_from_cbor_rejects_malformed_cid_links_without_panicking() {
+        let block_with_entry_link = |link: Vec<u8>| {
+            serde_cbor::Value::Array(vec![
+                serde_cbor::Value::Integer(2),    // Kind::Block
+                serde_cbor::Value::Integer(1),    // slot
+                serde_cbor::Value::Array(vec![]), // shredding
+                serde_cbor::Value::Array(vec![serde_cbor::Value::Bytes(link)]), // entries
+            ])
+        };
+
+        // Empty byte string: `bytes[1..]` used to panic with an out-of-range slice start.
+        assert!(Block::from_cbor(block_with_entry_link(vec![])).is_err());
+        // Valid prefix but non-CID payload: `Cid::try_from(..).unwrap()` used to panic.
+        assert!(Block::from_cbor(block_with_entry_link(vec![0, 1, 2, 3])).is_err());
+
+        // A well-formed link still decodes without error.
+        let valid_cid = vec![
+            1, 113, 18, 32, 56, 148, 167, 251, 237, 117, 200, 226, 181, 134, 79, 115, 131, 220,
+            232, 143, 20, 67, 224, 179, 48, 130, 197, 123, 226, 85, 85, 56, 38, 84, 106, 225,
+        ];
+        let mut link = vec![0u8];
+        link.extend_from_slice(&valid_cid);
+        let decoded = Block::from_cbor(block_with_entry_link(link)).expect("valid link decodes");
+        assert_eq!(decoded.entries.len(), 1);
+    }
 
     #[test]
     fn test_block() {

--- a/jetstreamer-firehose/src/dataframe.rs
+++ b/jetstreamer-firehose/src/dataframe.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{SharedError, node::Kind, utils::Buffer},
+    crate::{SharedError, node::Kind, node_reader::cid_from_cbor_link, utils::Buffer},
     cid::Cid,
     std::vec::Vec,
 };
@@ -83,9 +83,7 @@ impl DataFrame {
                 } else {
                     let mut nexts = vec![];
                     for cid in next {
-                        if let serde_cbor::Value::Bytes(cid) = cid {
-                            nexts.push(Cid::try_from(cid[1..].to_vec()).unwrap());
-                        }
+                        nexts.push(cid_from_cbor_link(cid)?);
                     }
                     data_frame.next = Some(nexts);
                 }

--- a/jetstreamer-firehose/src/entry.rs
+++ b/jetstreamer-firehose/src/entry.rs
@@ -2,6 +2,7 @@ use {
     crate::{
         SharedError,
         node::Kind,
+        node_reader::cid_from_cbor_link,
         utils::{self, Hash},
     },
     cid::Cid,
@@ -67,11 +68,7 @@ impl Entry {
 
             if let Some(serde_cbor::Value::Array(transactions)) = &array.get(3) {
                 for transaction in transactions {
-                    if let serde_cbor::Value::Bytes(transaction) = transaction {
-                        entry
-                            .transactions
-                            .push(Cid::try_from(transaction[1..].to_vec()).unwrap());
-                    }
+                    entry.transactions.push(cid_from_cbor_link(transaction)?);
                 }
             }
         }

--- a/jetstreamer-firehose/src/epoch.rs
+++ b/jetstreamer-firehose/src/epoch.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{SharedError, node::Kind},
+    crate::{SharedError, node::Kind, node_reader::cid_from_cbor_link},
     cid::Cid,
     std::vec::Vec,
 };
@@ -57,11 +57,7 @@ impl Epoch {
 
             if let Some(serde_cbor::Value::Array(subsets)) = &array.get(2) {
                 for subset in subsets {
-                    if let serde_cbor::Value::Bytes(subset) = subset {
-                        epoch
-                            .subsets
-                            .push(Cid::try_from(subset[1..].to_vec()).unwrap());
-                    }
+                    epoch.subsets.push(cid_from_cbor_link(subset)?);
                 }
             }
         }

--- a/jetstreamer-firehose/src/subset.rs
+++ b/jetstreamer-firehose/src/subset.rs
@@ -1,5 +1,5 @@
 use {
-    crate::{SharedError, node::Kind},
+    crate::{SharedError, node::Kind, node_reader::cid_from_cbor_link},
     cid::Cid,
     std::vec::Vec,
 };
@@ -63,11 +63,7 @@ impl Subset {
 
             if let Some(serde_cbor::Value::Array(blocks)) = &array.get(3) {
                 for block in blocks {
-                    if let serde_cbor::Value::Bytes(block) = block {
-                        subset
-                            .blocks
-                            .push(Cid::try_from(block[1..].to_vec()).unwrap());
-                    }
+                    subset.blocks.push(cid_from_cbor_link(block)?);
                 }
             }
         }


### PR DESCRIPTION
## What

The firehose node decoders build CID links with `Cid::try_from(bytes[1..].to_vec()).unwrap()`. Two operations there can panic on input that an untrusted Old Faithful archive fully controls:

- slicing `bytes[1..]` panics with an out of range start index when the CBOR byte string is empty
- `Cid::try_from(..).unwrap()` panics when the remaining bytes are not a valid CID

These links are decoded on the live replay path (`RawNode::parse` calls `parse_any_from_cbordata`), so a single malformed link in a fetched CAR node unwinds the worker future mid stream instead of failing gracefully.

## Change

Route every link through the existing `cid_from_cbor_link` helper, which already validates the DAG-CBOR `0x00` multibase prefix and returns a `Result`. The error now propagates with `?` rather than panicking. This covers:

- entries and rewards links in `Block`
- transaction links in `Entry`
- subset links in `Epoch`
- block links in `Subset`
- continuation links in `DataFrame`

Valid links decode exactly as before. The rewards branch keeps its existing `Value::Bytes` guard, so a block without a rewards link is still accepted unchanged.

## Test

Added a regression test that decodes a block carrying an empty byte string and a non CID link, and asserts both return an error instead of panicking, while a well formed link still decodes.

`cargo test -p jetstreamer-firehose --lib` passes with the network integration tests skipped.
