### PR TITLE
Add --help/-h and --version/-V

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -739,8 +739,41 @@ impl BuiltinPlugin {
 /// }
 /// ```
 pub fn parse_cli_args() -> Result<CliInvocation, Box<dyn std::error::Error>> {
-    let mut args = std::env::args();
-    args.next(); // binary name
+    parse_cli_args_from(std::env::args())
+}
+
+/// Parses a Jetstreamer invocation from an explicit argument list.
+///
+/// Identical to [`parse_cli_args`], except the arguments are supplied by the caller instead of
+/// being read from the process environment. `args` must start with the binary name, exactly as
+/// [`std::env::args`] yields it; the first element is skipped.
+///
+/// Environment variables are still consulted for the settings documented on [`parse_cli_args`] —
+/// only the argument list is redirected.
+///
+/// # Errors
+///
+/// Returns an error when the range argument is missing or malformed, when a flag is
+/// unrecognized, when a value-taking flag is missing its value, or when `--no-plugins` is
+/// combined with `--with-plugin`.
+///
+/// # Examples
+///
+/// ```
+/// # use jetstreamer::{parse_cli_args_from, CliInvocation};
+/// let invocation =
+///     parse_cli_args_from(["jetstreamer", "--list-plugins"].map(String::from)).expect("parsed");
+/// assert!(matches!(invocation, CliInvocation::ListPlugins));
+///
+/// // A missing range argument is a recoverable error, not a panic.
+/// assert!(parse_cli_args_from(["jetstreamer"].map(String::from)).is_err());
+/// ```
+pub fn parse_cli_args_from<I>(args: I) -> Result<CliInvocation, Box<dyn std::error::Error>>
+where
+    I: IntoIterator<Item = String>,
+{
+    let raw: Vec<String> = args.into_iter().collect();
+    let mut args = raw.iter().skip(1).cloned();
     let mut first_arg: Option<String> = None;
     let mut builtin_plugins = Vec::new();
     let mut no_plugins = false;
@@ -796,7 +829,10 @@ pub fn parse_cli_args() -> Result<CliInvocation, Box<dyn std::error::Error>> {
             other => return Err(format!("unrecognized argument '{other}'").into()),
         }
     }
-    let first_arg = first_arg.expect("no first argument given");
+    let first_arg = first_arg.ok_or(
+        "missing range argument; expected <epoch>, <start>-<end>, or <start>:<end> \
+         (for example: jetstreamer 950)",
+    )?;
     if no_plugins && !builtin_plugins.is_empty() {
         return Err("--no-plugins cannot be combined with --with-plugin".into());
     }
@@ -805,7 +841,6 @@ pub fn parse_cli_args() -> Result<CliInvocation, Box<dyn std::error::Error>> {
     // a flag value that happens to equal the positional cannot be mistaken for it.
     {
         const VALUE_FLAGS: [&str; 3] = ["--with-plugin", "--buffer-window", "--clickhouse-dsn"];
-        let raw: Vec<String> = std::env::args().collect();
         let mut parts: Vec<String> = Vec::with_capacity(raw.len());
         let mut index = 0;
         let mut replaced = false;
@@ -829,13 +864,16 @@ pub fn parse_cli_args() -> Result<CliInvocation, Box<dyn std::error::Error>> {
         }
         jetstreamer_plugin::metrics::set_resume_command_template(parts.join(" "));
     }
-    let slot_range = if first_arg.contains(':') {
-        let (slot_a, slot_b) = first_arg
-            .split_once(':')
-            .expect("failed to parse slot range, expected format: <start>:<end> or a single epoch");
-        let slot_a: u64 = slot_a.parse().expect("failed to parse first slot");
-        let slot_b: u64 = slot_b.parse().expect("failed to parse second slot");
-        slot_a..(slot_b + 1)
+    let slot_range = if let Some((slot_a, slot_b)) = first_arg.split_once(':') {
+        let slot_a: u64 = slot_a
+            .trim()
+            .parse()
+            .map_err(|_| format!("failed to parse first slot in range '{first_arg}'"))?;
+        let slot_b: u64 = slot_b
+            .trim()
+            .parse()
+            .map_err(|_| format!("failed to parse second slot in range '{first_arg}'"))?;
+        slot_a..slot_b.saturating_add(1)
     } else if let Some((epoch_a, epoch_b)) = first_arg.split_once('-') {
         let epoch_a: u64 = epoch_a
             .trim()
@@ -856,7 +894,10 @@ pub fn parse_cli_args() -> Result<CliInvocation, Box<dyn std::error::Error>> {
         let (_, end_slot_inclusive) = jetstreamer_firehose::epochs::epoch_to_slot_range(epoch_b);
         start_slot..(end_slot_inclusive + 1)
     } else {
-        let epoch: u64 = first_arg.parse().expect("failed to parse epoch");
+        let epoch: u64 = first_arg
+            .trim()
+            .parse()
+            .map_err(|_| format!("failed to parse epoch '{first_arg}'"))?;
         log::info!("epoch: {}", epoch);
         let (start_slot, end_slot_inclusive) =
             jetstreamer_firehose::epochs::epoch_to_slot_range(epoch);
@@ -971,5 +1012,136 @@ mod tests {
     fn builtin_plugin_from_flag_rejects_unknown() {
         assert!(BuiltinPlugin::from_flag("not-a-plugin").is_none());
         assert!(BuiltinPlugin::from_flag("").is_none());
+    }
+
+    /// Builds an argument list with the leading binary name [`parse_cli_args_from`] expects.
+    fn args(rest: &[&str]) -> Vec<String> {
+        std::iter::once("jetstreamer")
+            .chain(rest.iter().copied())
+            .map(String::from)
+            .collect()
+    }
+
+    fn slot_range(rest: &[&str]) -> std::ops::Range<u64> {
+        match parse_cli_args_from(args(rest)).expect("parsed") {
+            CliInvocation::Run(config) => config.slot_range,
+            CliInvocation::ListPlugins => panic!("expected a run invocation"),
+        }
+    }
+
+    // Each of the four cases below used to panic instead of returning `Err`, despite the
+    // function's `Result` return type.
+
+    #[test]
+    fn missing_range_argument_is_an_error() {
+        let err = parse_cli_args_from(args(&[])).expect_err("missing range must be an error");
+        assert!(
+            err.to_string().contains("missing range argument"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn non_numeric_epoch_is_an_error() {
+        let err = parse_cli_args_from(args(&["notanepoch"])).expect_err("must be an error");
+        assert!(
+            err.to_string().contains("failed to parse epoch"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn non_numeric_slot_range_bounds_are_errors() {
+        for range in ["abc:def", "abc:200", "100:def"] {
+            let err = parse_cli_args_from(args(&[range])).expect_err("must be an error");
+            assert!(
+                err.to_string().contains("failed to parse"),
+                "unexpected error for '{range}': {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn slot_range_upper_bound_saturates_instead_of_overflowing() {
+        assert_eq!(slot_range(&["0:18446744073709551615"]), 0..u64::MAX);
+    }
+
+    // Regression cover for reading arguments from the supplied list rather than `std::env::args`.
+
+    #[test]
+    fn single_epoch_expands_to_its_slot_range() {
+        let (start, end_inclusive) = jetstreamer_firehose::epochs::epoch_to_slot_range(950);
+        assert_eq!(slot_range(&["950"]), start..end_inclusive + 1);
+    }
+
+    #[test]
+    fn epoch_range_is_inclusive_on_both_ends() {
+        let (start, _) = jetstreamer_firehose::epochs::epoch_to_slot_range(900);
+        let (_, end_inclusive) = jetstreamer_firehose::epochs::epoch_to_slot_range(950);
+        assert_eq!(slot_range(&["900-950"]), start..end_inclusive + 1);
+    }
+
+    #[test]
+    fn slot_range_is_inclusive_on_both_ends() {
+        assert_eq!(slot_range(&["410400000:410832000"]), 410400000..410832001);
+    }
+
+    #[test]
+    fn reversed_epoch_range_is_an_error() {
+        let err = parse_cli_args_from(args(&["950-900"])).expect_err("must be an error");
+        assert!(
+            err.to_string().contains("reversed"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn list_plugins_short_circuits_before_the_range_argument() {
+        let invocation = parse_cli_args_from(args(&["--list-plugins"])).expect("parsed");
+        assert!(matches!(invocation, CliInvocation::ListPlugins));
+    }
+
+    #[test]
+    fn unrecognized_flag_is_an_error() {
+        let err = parse_cli_args_from(args(&["950", "--nope"])).expect_err("must be an error");
+        assert!(
+            err.to_string().contains("unrecognized argument"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn value_taking_flags_require_a_value() {
+        for flag in ["--with-plugin", "--buffer-window", "--clickhouse-dsn"] {
+            let err = parse_cli_args_from(args(&["950", flag])).expect_err("must be an error");
+            assert!(
+                err.to_string().contains(flag),
+                "unexpected error for '{flag}': {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn no_plugins_conflicts_with_with_plugin() {
+        let err = parse_cli_args_from(args(&[
+            "950",
+            "--no-plugins",
+            "--with-plugin",
+            "pubkey-stats",
+        ]))
+        .expect_err("must be an error");
+        assert!(
+            err.to_string().contains("cannot be combined"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[test]
+    fn positional_range_is_accepted_after_flags() {
+        let (start, end_inclusive) = jetstreamer_firehose::epochs::epoch_to_slot_range(950);
+        assert_eq!(
+            slot_range(&["--sequential", "950"]),
+            start..end_inclusive + 1
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -457,6 +457,8 @@ impl JetstreamerRunner {
                 Ok(JetstreamerInvocation::Run(self))
             }
             CliInvocation::ListPlugins => Ok(JetstreamerInvocation::ListPlugins),
+            CliInvocation::Help => Ok(JetstreamerInvocation::Help),
+            CliInvocation::Version => Ok(JetstreamerInvocation::Version),
         }
     }
 
@@ -617,6 +619,10 @@ pub enum CliInvocation {
     Run(Config),
     /// Print every built-in plugin name (see [`BuiltinPlugin::ALL`]) and exit.
     ListPlugins,
+    /// Print [`help_text`] and exit successfully.
+    Help,
+    /// Print the crate version and exit successfully.
+    Version,
 }
 
 /// Outcome of [`JetstreamerRunner::parse_cli_args`]; mirrors [`CliInvocation`].
@@ -625,6 +631,10 @@ pub enum JetstreamerInvocation {
     Run(JetstreamerRunner),
     /// Print every built-in plugin name (see [`BuiltinPlugin::ALL`]) and exit.
     ListPlugins,
+    /// Print [`help_text`] and exit successfully.
+    Help,
+    /// Print the crate version and exit successfully.
+    Version,
 }
 
 /// Runtime configuration for [`JetstreamerRunner`].
@@ -742,6 +752,51 @@ pub fn parse_cli_args() -> Result<CliInvocation, Box<dyn std::error::Error>> {
     parse_cli_args_from(std::env::args())
 }
 
+/// Usage text printed in response to [`CliInvocation::Help`].
+///
+/// Lists the accepted range grammar and every flag [`parse_cli_args`] understands. Runtime
+/// tuning is done through environment variables, which are documented at the crate root rather
+/// than repeated here.
+pub fn help_text() -> String {
+    let plugins = BuiltinPlugin::ALL
+        .iter()
+        .map(|plugin| plugin.name())
+        .collect::<Vec<_>>()
+        .join(", ");
+    format!(
+        "jetstreamer {version}
+High-throughput Solana ledger streaming and plugin framework.
+
+USAGE:
+    jetstreamer <range> [OPTIONS]
+
+RANGE:
+    <epoch>            a single epoch, e.g. 950
+    <start>-<end>      an inclusive epoch range, e.g. 900-950
+    <start>:<end>      an inclusive slot range, e.g. 410400000:410832000
+                       (slot ranges may cross epoch boundaries)
+
+OPTIONS:
+    --with-plugin <name>   enable a built-in plugin; repeatable
+                           one of: {plugins}
+                           [default: {default_plugin}]
+    --no-plugins           disable all built-in plugins
+    --list-plugins         print every built-in plugin name and exit
+    --sequential           use a single worker with ripget sequential streaming
+    --reverse              stream epochs highest to lowest; implies --sequential
+    --buffer-window <size> ripget window size in sequential mode, e.g. 4GiB
+    --clickhouse-dsn <url> override the ClickHouse DSN
+    --tui                  render the interactive dashboard instead of logs
+    -h, --help             print this help and exit
+    -V, --version          print the version and exit
+
+Runtime tuning is also available through JETSTREAMER_* environment variables;
+see https://docs.rs/jetstreamer for the full list.",
+        version = env!("CARGO_PKG_VERSION"),
+        default_plugin = BuiltinPlugin::ProgramTracking.name(),
+    )
+}
+
 /// Parses a Jetstreamer invocation from an explicit argument list.
 ///
 /// Identical to [`parse_cli_args`], except the arguments are supplied by the caller instead of
@@ -803,6 +858,12 @@ where
             }
             "--list-plugins" => {
                 return Ok(CliInvocation::ListPlugins);
+            }
+            "--help" | "-h" => {
+                return Ok(CliInvocation::Help);
+            }
+            "--version" | "-V" => {
+                return Ok(CliInvocation::Version);
             }
             "--sequential" => {
                 sequential_cli = true;
@@ -1025,7 +1086,7 @@ mod tests {
     fn slot_range(rest: &[&str]) -> std::ops::Range<u64> {
         match parse_cli_args_from(args(rest)).expect("parsed") {
             CliInvocation::Run(config) => config.slot_range,
-            CliInvocation::ListPlugins => panic!("expected a run invocation"),
+            other => panic!("expected a run invocation, got {other:?}"),
         }
     }
 
@@ -1134,6 +1195,69 @@ mod tests {
             err.to_string().contains("cannot be combined"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn help_and_version_flags_are_recognized() {
+        for flag in ["--help", "-h"] {
+            assert!(
+                matches!(
+                    parse_cli_args_from(args(&[flag])).expect("parsed"),
+                    CliInvocation::Help
+                ),
+                "'{flag}' should request help"
+            );
+        }
+        for flag in ["--version", "-V"] {
+            assert!(
+                matches!(
+                    parse_cli_args_from(args(&[flag])).expect("parsed"),
+                    CliInvocation::Version
+                ),
+                "'{flag}' should request the version"
+            );
+        }
+    }
+
+    #[test]
+    fn help_short_circuits_before_the_range_argument() {
+        // Without a `--help` arm these were parsed as a malformed epoch range, because
+        // `"--help".split_once('-')` succeeds.
+        assert!(matches!(
+            parse_cli_args_from(args(&["--help"])).expect("parsed"),
+            CliInvocation::Help
+        ));
+        assert!(matches!(
+            parse_cli_args_from(args(&["--version"])).expect("parsed"),
+            CliInvocation::Version
+        ));
+    }
+
+    #[test]
+    fn help_text_documents_every_flag_the_parser_accepts() {
+        let help = help_text();
+        for flag in [
+            "--with-plugin",
+            "--no-plugins",
+            "--list-plugins",
+            "--sequential",
+            "--reverse",
+            "--buffer-window",
+            "--clickhouse-dsn",
+            "--tui",
+            "--help",
+            "--version",
+        ] {
+            assert!(help.contains(flag), "help text is missing '{flag}'");
+        }
+        for plugin in BuiltinPlugin::ALL {
+            assert!(
+                help.contains(plugin.name()),
+                "help text is missing plugin '{}'",
+                plugin.name()
+            );
+        }
+        assert!(help.contains(env!("CARGO_PKG_VERSION")));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -735,7 +735,7 @@ impl BuiltinPlugin {
 /// # Examples
 ///
 /// ```no_run
-/// # use jetstreamer::{parse_cli_args, CliInvocation};
+/// # use jetstreamer::{parse_cli_args, help_text, BuiltinPlugin, CliInvocation};
 /// # unsafe {
 /// #     std::env::set_var("JETSTREAMER_THREADS", "3");
 /// #     std::env::set_var("JETSTREAMER_CLICKHOUSE_MODE", "off");
@@ -745,7 +745,13 @@ impl BuiltinPlugin {
 ///         assert_eq!(config.threads, 3);
 ///         assert!(!config.clickhouse_enabled);
 ///     }
-///     CliInvocation::ListPlugins => {}
+///     CliInvocation::ListPlugins => {
+///         for plugin in BuiltinPlugin::ALL {
+///             println!("{}", plugin.name());
+///         }
+///     }
+///     CliInvocation::Help => println!("{}", help_text()),
+///     CliInvocation::Version => println!("jetstreamer {}", env!("CARGO_PKG_VERSION")),
 /// }
 /// ```
 pub fn parse_cli_args() -> Result<CliInvocation, Box<dyn std::error::Error>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use jetstreamer::{BuiltinPlugin, JetstreamerInvocation, JetstreamerRunner};
+use jetstreamer::{BuiltinPlugin, JetstreamerInvocation, JetstreamerRunner, help_text};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     match JetstreamerRunner::default()
@@ -12,6 +12,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             for plugin in BuiltinPlugin::ALL {
                 println!("{}", plugin.name());
             }
+        }
+        JetstreamerInvocation::Help => println!("{}", help_text()),
+        JetstreamerInvocation::Version => {
+            println!("jetstreamer {}", env!("CARGO_PKG_VERSION"));
         }
     }
     Ok(())


### PR DESCRIPTION
> **Stacked on #91.** That PR splits `parse_cli_args_from` out of `parse_cli_args`, which is what makes the tests here possible. Until #91 merges this PR's diff will also show its commit — review only the second commit, `Add --help/-h and --version/-V`. Please merge #91 first.

Neither flag was handled, so both fell through to the positional range parser. Because `--help` contains a `-`, `split_once('-')` matched it and it was reported as a malformed epoch range.

On `main` (`cffaf3d`):

```
$ jetstreamer --help
Error: "failed to parse first epoch in range '--help'"

$ jetstreamer --version
Error: "failed to parse first epoch in range '--version'"
```

After:

```
$ jetstreamer --help
jetstreamer 0.7.0
High-throughput Solana ledger streaming and plugin framework.

USAGE:
    jetstreamer <range> [OPTIONS]

RANGE:
    <epoch>            a single epoch, e.g. 950
    <start>-<end>      an inclusive epoch range, e.g. 900-950
    <start>:<end>      an inclusive slot range, e.g. 410400000:410832000
                       (slot ranges may cross epoch boundaries)

OPTIONS:
    --with-plugin <name>   enable a built-in plugin; repeatable
                           one of: program-tracking, instruction-tracking, pubkey-stats
                           [default: program-tracking]
    --no-plugins           disable all built-in plugins
    --list-plugins         print every built-in plugin name and exit
    --sequential           use a single worker with ripget sequential streaming
    --reverse              stream epochs highest to lowest; implies --sequential
    --buffer-window <size> ripget window size in sequential mode, e.g. 4GiB
    --clickhouse-dsn <url> override the ClickHouse DSN
    --tui                  render the interactive dashboard instead of logs
    -h, --help             print this help and exit
    -V, --version          print the version and exit

Runtime tuning is also available through JETSTREAMER_* environment variables;
see https://docs.rs/jetstreamer for the full list.

$ jetstreamer -V
jetstreamer 0.7.0
```

## Approach

Follows the existing `--list-plugins` shape rather than inventing a new one: the parser returns a `CliInvocation` variant and the caller performs the action, so the library still never prints or exits on its own — as the `CliInvocation` doc comment states.

`help_text()` is generated from `BuiltinPlugin::ALL` and `CARGO_PKG_VERSION` instead of being hardcoded, so the plugin list and version can't drift from the code. A test asserts the help text mentions every flag the parser accepts, so adding a flag without documenting it fails CI.

## Breaking change

Adding variants to `CliInvocation` and `JetstreamerInvocation` breaks downstream code that matches on them exhaustively.

I tried `#[non_exhaustive]` on both enums to prevent this recurring, but it requires a catch-all arm in `src/main.rs`, which would silently swallow future variants in this repo's own binary — the opposite of what you want there. Left off so the compiler keeps `main.rs` honest. Happy to add it if you'd rather protect external consumers; it's a one-line change plus a catch-all in `main.rs`.

## Tests

3 new tests (18 total in `src/lib.rs`): flag recognition for all four spellings, short-circuiting before the range argument, and the help-text completeness check.

`cargo fmt --check`, `cargo clippy --workspace --all-targets`, and `cargo doc` are clean.